### PR TITLE
Add agent-runtime, CLI, and test-engine skills

### DIFF
--- a/buildkite-skills-proposal-v2.md
+++ b/buildkite-skills-proposal-v2.md
@@ -2,14 +2,15 @@
 
 ## Skills overview
 
-6 skills. 4 journey-based, 2 cross-cutting. Organized by what users are trying to accomplish, not Buildkite's product surface.
+7 skills. 4 journey-based, 3 cross-cutting. Organized by what users are trying to accomplish, not Buildkite's product surface.
 
 | Skill | Type | Persona | Scope |
 |-------|------|---------|-------|
-| **`buildkite-pipelines`** | Journey | Every developer | Pipeline YAML: caching, parallelism, annotations, retry, if_changed, dynamic pipelines, matrix, plugins, notifications, artifacts |
+| **`buildkite-pipelines`** | Journey | Every developer | Pipeline YAML: caching, parallelism, retry, `if_changed`, dynamic pipelines, matrix, plugins, notifications, artifact paths, concurrency |
 | **`buildkite-test-engine`** | Journey | Devs with slow/flaky tests | bktec CLI, test splitting, flaky detection, quarantine, collectors, suite setup, `BUILDKITE_TEST_ENGINE_*` env vars |
 | **`buildkite-secure-delivery`** | Journey (Phase 2) | Devs shipping artifacts | OIDC auth, Package Registry, SLSA provenance, pipeline signing (JWKS), end-to-end secure publish flow |
 | **`buildkite-platform-engineering`** | Journey | Platform teams | Clusters, queues, hosted agents, instance shapes, cluster secrets, agent config, templates, audit logging, SSO, cost optimization |
+| **`buildkite-agent-runtime`** | Cross-cutting | Every developer (in-job) | `buildkite-agent` subcommands used inside job steps: annotate, artifact, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor |
 | **`buildkite-cli`** | Cross-cutting | Everyone (terminal) | `bk` CLI: builds, jobs, pipelines, secrets, artifacts, auth |
 | **`buildkite-api`** | Cross-cutting | Automation engineers | REST API, GraphQL API, webhooks, authentication, pagination |
 
@@ -19,12 +20,15 @@ Each skill owns specific topics. Others cross-reference with one sentence + poin
 
 | Topic | Owner | Do NOT duplicate in |
 |-------|-------|--------------------|
-| `pipeline.yml` syntax, step types, caching, parallelism, annotations, retry, `if_changed`, dynamic pipelines, matrix, plugins, `notify:`, artifact YAML, concurrency, `agents:` queue routing | **buildkite-pipelines** | Any other skill |
+| `pipeline.yml` syntax, step types, caching, parallelism, retry, `if_changed`, dynamic pipelines, matrix, plugins, `notify:`, `artifact_paths:`, concurrency, `agents:` queue routing, `secrets:` | **buildkite-pipelines** | Any other skill |
 | Test Engine suites, `bktec` CLI, test splitting, flaky detection, quarantine, test collectors, `BUILDKITE_TEST_ENGINE_*` env vars, reliability scores | **buildkite-test-engine** | Any other skill |
-| OIDC token requests, Package Registry, SLSA provenance, `generate-provenance-attestation` plugin, pipeline signing (JWKS), verification config | **buildkite-secure-delivery** | Any other skill |
-| Clusters, queues, hosted agent instance shapes, cluster secrets, `buildkite-agent.cfg`, agent tokens, agent lifecycle hooks, pipeline templates, audit logging, SSO/SAML, cost tracking, organization settings | **buildkite-platform-engineering** | Any other skill |
+| End-to-end secure publish flows, Package Registry setup, SLSA provenance patterns, pipeline signing (JWKS) config, verification rollout strategy | **buildkite-secure-delivery** | Any other skill |
+| Clusters, queues, hosted agent instance shapes, cluster secrets setup, `buildkite-agent.cfg`, agent tokens, agent lifecycle hooks, pipeline templates, audit logging, SSO/SAML, cost tracking, org settings | **buildkite-platform-engineering** | Any other skill |
+| `buildkite-agent annotate`, `artifact upload/download/search/shasum`, `meta-data set/get/exists/keys`, `pipeline upload`, `oidc request-token`, `step get/update/cancel`, `lock acquire/release/get/do`, `env dump/get/set/unset`, `secret get`, `redactor add`, `tool sign/verify` — command syntax, flags, examples | **buildkite-agent-runtime** | Any other skill |
 | `bk build`, `bk job`, `bk pipeline`, `bk secret`, `bk artifact`, `bk auth` — command syntax, flags, examples | **buildkite-cli** | Any other skill |
 | REST API endpoints, GraphQL schema/mutations, webhook setup, API authentication, pagination | **buildkite-api** | Any other skill |
+
+**Ambiguity rule — pipelines vs agent-runtime:** The pipeline YAML *concept* (when to annotate, why to use dynamic pipelines, artifact_paths syntax) belongs to **buildkite-pipelines**. The *command syntax* for executing it inside a step (`buildkite-agent annotate --style error`, `buildkite-agent pipeline upload`) belongs to **buildkite-agent-runtime**. Pipelines teaches the *what and why*. Agent-runtime teaches the *how to invoke*.
 
 ### Execution paths — skills vs MCP vs CLI vs API
 
@@ -33,6 +37,7 @@ Skills teach *knowledge*. The agent *acts* through different execution paths dep
 | Agent needs to... | Knowledge source | Executes via |
 |-------------------|-----------------|--------------|
 | Write or edit `pipeline.yml` | Journey skill | File edit |
+| Write `buildkite-agent` commands inside step scripts | `buildkite-agent-runtime` | File edit (inline in step `command:`) |
 | Inspect a build, read logs, check queue depth | Journey skill (for *why*) | **Buildkite MCP server** tools (direct access) |
 | Run a `bk` command | `buildkite-cli` | Bash |
 | Run `bktec` for test splitting | `buildkite-test-engine` | Bash |
@@ -44,7 +49,7 @@ Skills teach *knowledge*. The agent *acts* through different execution paths dep
 
 v1 organized skills by **product surface** (pipeline YAML, agent binary, CLI tool, platform APIs). That mirrors Buildkite's internal org chart, not how users think.
 
-v2 organizes by **user journey**. When someone asks an AI agent for help, they're in the middle of a job — not browsing a product catalog. The framework reveals 4 distinct journeys that users travel through, and 2 cross-cutting needs that show up throughout.
+v2 organizes by **user journey**. When someone asks an AI agent for help, they're in the middle of a job — not browsing a product catalog. The framework reveals 4 distinct journeys that users travel through, and 3 cross-cutting needs that show up throughout.
 
 ---
 
@@ -52,10 +57,11 @@ v2 organizes by **user journey**. When someone asks an AI agent for help, they'r
 
 | Skill | Type | Jobs | Persona | What it teaches |
 |-------|------|------|---------|-----------------|
-| `buildkite-pipelines` | Journey | J1, J2, J3 | Every developer | Pipeline YAML: caching, parallelism, annotations, retry, if_changed, dynamic pipelines, matrix, plugins |
+| `buildkite-pipelines` | Journey | J1, J2, J3 | Every developer | Pipeline YAML: caching, parallelism, retry, if_changed, dynamic pipelines, matrix, plugins |
 | `buildkite-test-engine` | Journey | J4, J5 | Developers with slow/flaky tests | Test Engine: bktec CLI, test splitting, flaky detection, quarantine, collectors |
-| `buildkite-secure-delivery` | Journey | J6, J7 | Developers shipping artifacts | OIDC auth, Package Registry, SLSA provenance, pipeline signing (JWKS) |
+| `buildkite-secure-delivery` | Journey (Phase 2) | J6, J7 | Developers shipping artifacts | OIDC auth, Package Registry, SLSA provenance, pipeline signing (JWKS) |
 | `buildkite-platform-engineering` | Journey | J8, J9 | Platform teams | Clusters, queues, hosted agents, secrets, agent config, templates, audit, SSO, cost |
+| `buildkite-agent-runtime` | Cross-cutting | All | Every developer (in-job) | `buildkite-agent` subcommands inside steps: annotate, artifact, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor |
 | `buildkite-cli` | Cross-cutting | All | Everyone (terminal) | `bk` CLI: builds, jobs, pipelines, secrets, artifacts, auth |
 | `buildkite-api` | Cross-cutting | All | Automation engineers | REST API, GraphQL API, webhooks, authentication |
 
@@ -91,6 +97,12 @@ The Buildkite MCP server gives agents **direct read/write access** to Buildkite 
 
 **The rule:** Skills teach *what to do and why*. The MCP server provides *the tool to do it*. A skill says "check queue depth to diagnose wait time" and points to `get_cluster_queue`. It does not document `get_cluster_queue`'s parameters.
 
+### Skills ↔ `buildkite-agent` runtime commands
+
+The `buildkite-agent-runtime` skill teaches agents the subcommands available *inside* a running job step — `annotate`, `artifact`, `meta-data`, `pipeline upload`, `oidc`, `step`, `lock`, `env`, `secret`, `redactor`, `tool`. These are commands that go inside your step's `command:` block.
+
+Journey skills say *when and why* to use these commands ("add an annotation on test failure"). The agent-runtime skill documents *how* to invoke them (flags, arguments, patterns). A journey skill references agent-runtime: "to create an annotation, see the **buildkite-agent-runtime** skill for `buildkite-agent annotate` syntax."
+
 ### Skills ↔ `bk` CLI
 
 The `buildkite-cli` skill teaches agents how to use the `bk` CLI — command syntax, flags, flag tables, examples. This is **core skill content, not duplication**. The skill teaches the knowledge; the agent executes via Bash.
@@ -108,9 +120,10 @@ Journey skills reference the API skill when they need programmatic access: "to c
 | Agent needs to... | Use | Why |
 |-------------------|-----|-----|
 | Read build status, logs, annotations right now | MCP server (`get_build`, `read_logs`) | Direct access, no API call construction needed |
-| Write pipeline YAML | Skill knowledge → file edit | Skills teach syntax, agent writes files |
-| Run a CLI command | Skill knowledge → Bash | `buildkite-cli` teaches syntax, agent runs via shell |
-| Write a script/integration that calls the API | Skill knowledge → code generation | `buildkite-api` teaches endpoints, agent writes code |
+| Write pipeline YAML | Skill knowledge → file edit | Journey skills teach syntax, agent writes files |
+| Write `buildkite-agent` commands inside step scripts | `buildkite-agent-runtime` → file edit | Agent-runtime teaches command syntax, agent writes it into step `command:` blocks |
+| Run a `bk` CLI command | `buildkite-cli` → Bash | CLI skill teaches syntax, agent runs via shell |
+| Write a script/integration that calls the API | `buildkite-api` → code generation | API skill teaches endpoints, agent writes code |
 | Understand *why* to do something (caching strategy, retry patterns, splitting approach) | Journey skill | Skills teach the reasoning and patterns |
 
 ---
@@ -131,7 +144,7 @@ Journey skills reference the API skill when they need programmatic access: "to c
 
 ---
 
-## 4 journey skills + 2 cross-cutting skills
+## 4 journey skills + 3 cross-cutting skills
 
 ### Journey 1: `buildkite-pipelines` — "Write and optimize my pipeline"
 
@@ -292,7 +305,45 @@ Journey skills reference the API skill when they need programmatic access: "to c
 
 ---
 
-### Cross-cutting 1: `buildkite-cli` — "Do things from my terminal"
+### Cross-cutting 1: `buildkite-agent-runtime` — "The in-job toolkit"
+
+**Jobs served:** All — used inside step scripts across every journey
+
+**What this is:** The `buildkite-agent` binary exposes subcommands that run *inside* a job step. This is the runtime toolkit for interacting with Buildkite from within your build scripts — creating annotations, uploading artifacts, sharing state between jobs, generating dynamic pipelines, requesting OIDC tokens, acquiring distributed locks, and more.
+
+**Why separate from pipelines:** The pipelines skill teaches *what to put in pipeline.yml* (declarative). This skill teaches *what commands to run inside your step scripts* (imperative). `artifact_paths: "dist/**"` is pipeline YAML (→ buildkite-pipelines). `buildkite-agent artifact upload "dist/**"` is a runtime command (→ buildkite-agent-runtime). Same outcome, different skill.
+
+**Why separate from platform-engineering:** Platform-engineering is about *setting up* agents — clusters, queues, `buildkite-agent.cfg`, tokens. This skill is about *using* the agent binary from within a running job. Different persona, different moment.
+
+**What triggers this skill:**
+- "buildkite-agent annotate", "buildkite-agent artifact", "buildkite-agent meta-data"
+- "upload pipeline dynamically", "pipeline upload"
+- "share data between steps", "meta-data set/get"
+- "request OIDC token", "buildkite-agent oidc"
+- "distributed lock", "buildkite-agent lock"
+- "get step attribute", "update step label"
+- "redact secret from logs", "buildkite-agent secret get"
+- Any `buildkite-agent <subcommand>` invocation inside a step
+
+**Content outline:**
+
+| Subcommand | What it does | Framework evidence |
+|------------|-------------|-------------------|
+| `annotate` | Create/update build annotations with styles (default, info, warning, error, success), context keys, markdown content | SURFACE phase — "show errors in the build page." The example pipeline uses annotate extensively for test summaries, triage checklists, and navigation. |
+| `artifact upload/download/search/shasum` | Upload files as build artifacts, download from current or other builds, search by glob, verify checksums | Used across all phases. SHARPEN uses artifacts for Docker manifests + SLSA attestations. |
+| `meta-data set/get/exists/keys` | Shared key-value store across all jobs in a build. Set in one job, read in another. | SKIP phase — dynamic pipeline generators read meta-data to pass state. Block step field values stored as meta-data. |
+| `pipeline upload` | Upload YAML (from file or stdin) to dynamically add steps to the running build | SKIP phase — the core of dynamic pipeline generation. The Python generator pipes YAML to `pipeline upload`. |
+| `oidc request-token` | Request a short-lived OIDC token for authentication to external services (package registries, cloud providers) | SHARPEN phase — `--audience URL --lifetime 300`, piped to `docker login --password-stdin`. |
+| `step get/update/cancel` | Read or modify step attributes at runtime (label, state, metadata). Cancel a running step. | Useful for conditional logic within steps and build automation. |
+| `lock acquire/release/get/do` | Distributed mutex locks across parallel jobs in the same build | SCALE phase — when parallel jobs need to coordinate (e.g., only one job runs a migration). |
+| `env dump/get/set/unset` | Inspect and modify the job's environment. `dump` outputs JSON for debugging hook changes. | Debugging lifecycle hooks — see what environment changes hooks made. |
+| `secret get` | Retrieve cluster secrets by name at runtime (alternative to `secrets:` YAML key) | Programmatic secret access within scripts when `secrets:` declarative approach isn't flexible enough. |
+| `redactor add` | Add values to the log redactor so they're masked in build output | Security — redact dynamically-retrieved secrets that weren't declared in `secrets:`. |
+| `tool sign/verify` | Sign or verify pipeline step definitions for integrity checking | SHARPEN phase — pipeline signing verification at the step level. |
+
+---
+
+### Cross-cutting 2: `buildkite-cli` — "Do things from my terminal"
 
 **Jobs served:** All (operational layer)
 
@@ -318,7 +369,7 @@ Journey skills reference the API skill when they need programmatic access: "to c
 
 ---
 
-### Cross-cutting 2: `buildkite-api` — "Automate and integrate programmatically"
+### Cross-cutting 3: `buildkite-api` — "Automate and integrate programmatically"
 
 **Jobs served:** J8, J6, J7 (automation layer)
 
@@ -350,10 +401,11 @@ Journey skills reference the API skill when they need programmatic access: "to c
 | Dimension | v1 | v2 |
 |-----------|----|----|
 | **Organizing principle** | Product surface (YAML, binary, CLI, APIs) | User journey (what are they trying to accomplish) |
-| **Number of skills** | 5 | 6 (4 journey + 2 cross-cutting) |
+| **Number of skills** | 5 | 7 (4 journey + 3 cross-cutting) |
 | **Biggest change** | Test Engine extracted from platform | Secure delivery + platform engineering split from catch-all "platform"; agent infra gets a real home |
 | **`buildkite-platform` (v1)** | Catch-all: APIs, webhooks, OIDC, SSO, Test Engine, packages, audit, templates | Split into 3 focused skills: secure-delivery, platform-engineering, api |
 | **`buildkite-agent` (v1)** | Standalone skill for agent binary | Clusters, queues, hosted agents, secrets, agent config → `buildkite-platform-engineering`. Signing → `buildkite-secure-delivery`. Queue routing in YAML → `buildkite-pipelines`. |
+| **`buildkite-agent` (v1)** runtime cmds | Mixed into pipelines skill | **buildkite-agent-runtime**: dedicated skill for in-job subcommands (annotate, artifact, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor) |
 | **CLI + API** | Separate (CLI only) | Separated: CLI (human terminal) vs API (programmatic automation) |
 
 ### What happened to `buildkite-agent`?
@@ -378,8 +430,14 @@ How user queries route to skills, and which execution path the agent uses:
 |-----------|-------|--------------------|---------------------|
 | "my build takes 20 minutes" | buildkite-pipelines | File edit (pipeline.yml) | `get_build`, `read_logs` to diagnose |
 | "add caching to this pipeline" | buildkite-pipelines | File edit | — |
-| "show test failures in the build page" | buildkite-pipelines | File edit (annotations) | `list_annotations` to check existing |
+| "show test failures in the build page" | buildkite-pipelines + buildkite-agent-runtime | File edit (pipeline YAML + annotate command) | `list_annotations` to check existing |
 | "only run tests when code changes" | buildkite-pipelines | File edit | — |
+| "add an annotation to this step" | buildkite-agent-runtime | File edit (step script) | — |
+| "share data between steps" | buildkite-agent-runtime | File edit (`meta-data set/get`) | — |
+| "upload pipeline dynamically from a script" | buildkite-agent-runtime | File edit (`pipeline upload`) | — |
+| "acquire a lock so parallel jobs don't collide" | buildkite-agent-runtime | File edit (`lock acquire/release`) | — |
+| "redact this secret from the logs" | buildkite-agent-runtime | File edit (`redactor add`) | — |
+| "get an OIDC token inside the step" | buildkite-agent-runtime | File edit (`oidc request-token`) | — |
 | "why did this build fail" | buildkite-pipelines | — (read-only) | `get_build`, `read_logs`, `list_annotations` |
 | "split my tests across 10 machines" | buildkite-test-engine | File edit + Bash (bktec) | `get_test_run`, `get_failed_executions` |
 | "is this test flaky" | buildkite-test-engine | — (read-only) | `get_test`, `list_test_runs` |

--- a/skills/buildkite-agent-runtime/SKILL.md
+++ b/skills/buildkite-agent-runtime/SKILL.md
@@ -1,0 +1,778 @@
+---
+name: buildkite-agent-runtime
+description: >
+  This skill should be used when the user asks to "add an annotation",
+  "upload artifacts from a step", "share data between steps", "upload pipeline
+  dynamically", "request an OIDC token inside a step", "acquire a distributed lock",
+  "get or update a step attribute", "redact a secret from logs", "retrieve a cluster
+  secret at runtime", or "debug environment variables in hooks".
+  Also use when the user mentions buildkite-agent annotate, buildkite-agent artifact
+  upload/download, buildkite-agent meta-data set/get, buildkite-agent pipeline upload,
+  buildkite-agent oidc request-token, buildkite-agent step, buildkite-agent lock,
+  buildkite-agent env, buildkite-agent secret get, buildkite-agent redactor add,
+  buildkite-agent tool sign/verify, or any buildkite-agent subcommand used inside
+  a running job step.
+---
+
+# Buildkite Agent Runtime
+
+The `buildkite-agent` binary provides subcommands for interacting with Buildkite from within running job steps — creating annotations, uploading artifacts, sharing state between jobs, generating dynamic pipelines, requesting OIDC tokens, and more. This skill covers the command syntax, flags, and patterns for every in-job subcommand.
+
+## Quick Start
+
+A step that runs tests, annotates failures, uploads coverage, and stores a result flag for downstream jobs:
+
+```yaml
+steps:
+  - label: ":test_tube: Tests"
+    command: |
+      if ! make test 2>&1 | tee test-output.txt; then
+        buildkite-agent annotate --style "error" --context "test-failures" < test-output.txt
+        buildkite-agent meta-data set "tests-passed" "false"
+        exit 1
+      fi
+      buildkite-agent annotate "All tests passed :white_check_mark:" --style "success" --context "test-results"
+      buildkite-agent artifact upload "coverage/**/*"
+      buildkite-agent meta-data set "tests-passed" "true"
+```
+
+A downstream step reading that state:
+
+```yaml
+  - label: ":rocket: Deploy"
+    command: |
+      PASSED=$(buildkite-agent meta-data get "tests-passed")
+      if [[ "$PASSED" != "true" ]]; then
+        echo "Tests did not pass, skipping deploy"
+        exit 0
+      fi
+      scripts/deploy.sh
+    depends_on: "test-step"
+```
+
+## Annotations
+
+Surface build results directly on the build page. Annotations support Markdown and HTML.
+
+### Creating annotations
+
+```bash
+# Simple text annotation
+buildkite-agent annotate "Deploy completed successfully" --style "success" --context "deploy"
+
+# Markdown annotation from a file
+buildkite-agent annotate --style "error" --context "test-failures" < test-output.md
+
+# Pipe from a generator script
+./scripts/build-summary.sh | buildkite-agent annotate --style "info" --context "summary"
+
+# Append to an existing annotation (same context)
+buildkite-agent annotate --style "warning" --context "lint" --append < lint-warnings.txt
+```
+
+### Annotation styles
+
+| Style | Use case |
+|-------|----------|
+| `default` | General information |
+| `info` | Build metadata, links, summaries |
+| `warning` | Non-blocking issues (lint warnings, deprecations) |
+| `error` | Test failures, build errors |
+| `success` | Passed checks, successful deploys |
+
+### Key flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--style` | `-s` | `default` | Visual style: `default`, `info`, `warning`, `error`, `success` |
+| `--context` | `-c` | random UUID | Unique ID — reusing a context replaces the annotation |
+| `--append` | — | `false` | Append to existing annotation with same context instead of replacing |
+| `--priority` | — | `3` | Display priority (1-10). Higher numbers appear first |
+| `--job` | — | current job | Job ID to annotate (rarely needed) |
+
+### Linking to artifacts in annotations
+
+```bash
+buildkite-agent artifact upload "coverage/index.html"
+buildkite-agent annotate --style "info" --context "coverage" \
+  'Coverage report: <a href="artifact://coverage/index.html">view</a>'
+```
+
+### Replacing vs appending
+
+- **Same `--context` without `--append`**: replaces the entire annotation
+- **Same `--context` with `--append`**: appends new content below existing content
+- **Different `--context`**: creates a separate annotation
+
+Use a stable `--context` value (e.g., `"test-failures"`, `"deploy-status"`) so reruns update the same annotation instead of creating duplicates.
+
+> For pipeline-level `notify:` configuration, see the **buildkite-pipelines** skill.
+
+## Artifacts
+
+Upload files as build artifacts, download them in later steps or other builds, search by glob, and verify checksums.
+
+### Upload
+
+```bash
+# Upload a single file
+buildkite-agent artifact upload "pkg/release.tar.gz"
+
+# Upload with glob pattern
+buildkite-agent artifact upload "dist/**/*"
+
+# Upload multiple patterns
+buildkite-agent artifact upload "logs/*.log;coverage/**/*"
+
+# Upload to a specific subdirectory in the artifact store
+buildkite-agent artifact upload "results/*" --content-type "application/json"
+```
+
+### Download
+
+```bash
+# Download to current directory
+buildkite-agent artifact download "pkg/release.tar.gz" .
+
+# Download to a specific directory
+buildkite-agent artifact download "dist/*" tmp/
+
+# Download from a specific step
+buildkite-agent artifact download "dist/*" . --step "build-step"
+
+# Download from another build
+buildkite-agent artifact download "dist/*" . --build "018e4f2a-7b3c-4a1e-9f5d-abc123def456"
+```
+
+### Search
+
+```bash
+# List matching artifacts
+buildkite-agent artifact search "pkg/*.tar.gz" --build "$BUILDKITE_BUILD_ID"
+
+# Custom output format (filename per line)
+buildkite-agent artifact search "*" --format "%p\n"
+
+# Search within a specific step
+buildkite-agent artifact search "logs/*" --step "test-step" --build "$BUILDKITE_BUILD_ID"
+```
+
+### Checksum verification
+
+```bash
+# SHA-1 (default)
+buildkite-agent artifact shasum "pkg/release.tar.gz" --build "$BUILDKITE_BUILD_ID"
+
+# SHA-256
+buildkite-agent artifact shasum "pkg/release.tar.gz" --sha256 --build "$BUILDKITE_BUILD_ID"
+```
+
+### Key flags — upload
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--job` | current job | Job ID to upload artifacts for |
+| `--content-type` | auto-detected | MIME type for the uploaded files |
+| `--glob` | — | File glob pattern (alternative to positional argument) |
+| `--follow-symlinks` | `false` | Follow symbolic links when resolving glob patterns |
+
+### Key flags — download
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--step` | — | Scope download to artifacts from a specific step (by key or ID) |
+| `--build` | current build | Download from a different build by UUID |
+| `--include-retried-jobs` | `false` | Include artifacts from retried jobs |
+
+> For the declarative `artifact_paths:` YAML key, see the **buildkite-pipelines** skill. For `bk artifact` CLI commands, see the **buildkite-cli** skill.
+
+## Meta-data
+
+A build-wide key-value store for sharing state between jobs. Set a value in one job, read it in any other job in the same build.
+
+### Set
+
+```bash
+# Set a key-value pair
+buildkite-agent meta-data set "release-version" "1.4.2"
+
+# Set from a file
+buildkite-agent meta-data set "changelog" < CHANGELOG.md
+
+# Set from a script's output
+./scripts/compute-hash.sh | buildkite-agent meta-data set "content-hash"
+```
+
+### Get
+
+```bash
+# Get a value
+VERSION=$(buildkite-agent meta-data get "release-version")
+
+# Get with a default (exit 0 even if key missing)
+ENV=$(buildkite-agent meta-data get "deploy-env" --default "staging")
+```
+
+### Check existence
+
+```bash
+# Returns exit code 0 if exists, 100 if not
+if buildkite-agent meta-data exists "release-version"; then
+  echo "Version already set"
+fi
+```
+
+### List keys
+
+```bash
+# List all meta-data keys for the current build
+buildkite-agent meta-data keys
+```
+
+### Key flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--job` | current job | Scope to a specific job (for `set`) |
+| `--build` | current build | Target a specific build by UUID |
+| `--default` | — | Default value if key not found (for `get` only; prevents non-zero exit) |
+
+### Common patterns
+
+**Block step field values** are stored automatically as meta-data. Retrieve them by field key:
+
+```bash
+# After a block step with fields: [{key: "release-name", text: "Release Name"}]
+RELEASE_NAME=$(buildkite-agent meta-data get "release-name")
+```
+
+**Passing structured data** — use JSON for complex values:
+
+```bash
+# Set
+echo '{"status":"pass","count":42}' | buildkite-agent meta-data set "test-results"
+
+# Get and parse
+buildkite-agent meta-data get "test-results" | jq -r '.status'
+```
+
+## Pipeline Upload
+
+Dynamically add steps to a running build. The core mechanism behind dynamic pipelines — generate YAML at runtime and upload it.
+
+### Basic usage
+
+```bash
+# Upload from default location (.buildkite/pipeline.yml)
+buildkite-agent pipeline upload
+
+# Upload a specific file
+buildkite-agent pipeline upload .buildkite/deploy-steps.yml
+
+# Pipe generated YAML from stdin
+./scripts/generate-pipeline.sh | buildkite-agent pipeline upload
+
+# Generate inline
+cat <<YAML | buildkite-agent pipeline upload
+steps:
+  - label: ":rocket: Deploy"
+    command: "scripts/deploy.sh"
+    branches: "main"
+YAML
+```
+
+### Replace mode
+
+By default, uploaded steps are **appended** after the current step. Use `--replace` to replace the entire remaining pipeline:
+
+```bash
+# Replace all remaining steps with the uploaded ones
+buildkite-agent pipeline upload --replace .buildkite/new-pipeline.yml
+```
+
+### Interpolation control
+
+Buildkite interpolates `$VARIABLE` and `${VARIABLE}` in uploaded YAML using the job's environment. Disable this when the YAML contains literal dollar signs:
+
+```bash
+# Skip variable interpolation
+buildkite-agent pipeline upload --no-interpolation dynamic-steps.yml
+```
+
+### Dry run
+
+Validate the pipeline YAML without uploading:
+
+```bash
+buildkite-agent pipeline upload --dry-run .buildkite/pipeline.yml
+```
+
+### Key flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--replace` | `false` | Replace remaining pipeline steps instead of appending |
+| `--no-interpolation` | `false` | Skip environment variable interpolation in the uploaded YAML |
+| `--dry-run` | `false` | Validate and output the pipeline without uploading |
+| `--reject-secrets` | `false` | Reject pipeline upload if it contains secrets in plain text |
+
+### Dynamic pipeline generator pattern
+
+A common pattern: a generator step reads repo state and emits YAML to `pipeline upload`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+CHANGED=$(git diff --name-only HEAD~1)
+
+cat <<YAML
+steps:
+YAML
+
+for dir in services/*/; do
+  svc=$(basename "$dir")
+  if echo "$CHANGED" | grep -q "^services/$svc/"; then
+    cat <<YAML
+  - label: ":test_tube: $svc"
+    command: "cd services/$svc && make test"
+YAML
+  fi
+done
+```
+
+Call it from a step:
+
+```yaml
+steps:
+  - label: ":pipeline: Generate"
+    command: .buildkite/generate-pipeline.sh | buildkite-agent pipeline upload
+```
+
+### Meta-data to pipeline upload pattern
+
+Combine meta-data from a block step with dynamic pipeline upload:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+RELEASE_NAME=$(buildkite-agent meta-data get "release-name")
+TARGET_ENV=$(buildkite-agent meta-data get "deploy-env")
+
+cat <<YAML | buildkite-agent pipeline upload
+steps:
+  - trigger: "deploy-pipeline"
+    label: "Deploy $RELEASE_NAME to $TARGET_ENV"
+    build:
+      meta_data:
+        release-name: "$RELEASE_NAME"
+        deploy-env: "$TARGET_ENV"
+YAML
+```
+
+> For pipeline YAML syntax and step types, see the **buildkite-pipelines** skill.
+
+## OIDC Tokens
+
+Request short-lived OpenID Connect tokens from within a job step for authenticating to external services (cloud providers, package registries) without static credentials.
+
+### Basic token request
+
+```bash
+# Request a token for a specific audience
+TOKEN=$(buildkite-agent oidc request-token --audience "https://packages.buildkite.com/my-org/my-registry")
+
+# Use it to authenticate (e.g., Docker registry)
+echo "$TOKEN" | docker login packages.buildkite.com --username buildkite --password-stdin
+```
+
+### Cloud provider authentication
+
+```bash
+# AWS — request token with STS audience
+TOKEN=$(buildkite-agent oidc request-token --audience "sts.amazonaws.com")
+
+# AWS — with session tags for fine-grained access
+TOKEN=$(buildkite-agent oidc request-token \
+  --audience "sts.amazonaws.com" \
+  --aws-session-tag "organization_slug,pipeline_slug")
+```
+
+### Token with custom claims
+
+Include optional claims in the token for downstream verification:
+
+```bash
+# Single claim
+buildkite-agent oidc request-token --audience "https://my-service.example.com" \
+  --claim "organization_id"
+
+# Multiple claims
+buildkite-agent oidc request-token --audience "https://my-service.example.com" \
+  --claim "organization_id,pipeline_id"
+```
+
+### Token lifetime
+
+```bash
+# Short-lived token (5 minutes) — recommended for most use cases
+buildkite-agent oidc request-token --audience "https://registry.example.com" --lifetime 300
+```
+
+### Key flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--audience` | Buildkite endpoint | Target service URL — must match the OIDC provider audience configuration |
+| `--lifetime` | `600` | Token lifetime in seconds |
+| `--claim` | — | Comma-separated optional claims to include (e.g., `organization_id,pipeline_id`) |
+| `--aws-session-tag` | — | Comma-separated claims to map as AWS session tags |
+
+### OIDC token claims
+
+Every token includes these standard claims automatically:
+
+| Claim | Example | Description |
+|-------|---------|-------------|
+| `sub` | `organization:my-org:pipeline:my-pipe:ref:refs/heads/main:commit:abc123:step:build` | Subject identifier |
+| `iss` | `https://agent.buildkite.com` | Token issuer |
+| `aud` | `sts.amazonaws.com` | Audience (from `--audience` flag) |
+| `organization_slug` | `my-org` | Buildkite organization |
+| `pipeline_slug` | `my-pipeline` | Pipeline that issued the token |
+| `build_number` | `123` | Build number |
+| `build_branch` | `main` | Git branch |
+| `build_commit` | `abc123def` | Git commit SHA |
+| `step_key` | `build` | Step key |
+| `job_id` | `018e4f2a-...` | Job UUID |
+
+> For end-to-end OIDC auth flows and package registry integration, see the **buildkite-secure-delivery** skill.
+
+## Step Management
+
+Read or modify step attributes at runtime. Useful for conditional logic within steps and build automation.
+
+### Get step attributes
+
+```bash
+# Get current step's label
+LABEL=$(buildkite-agent step get "label")
+
+# Get another step's attribute by key
+STATE=$(buildkite-agent step get "state" --step "deploy-step")
+
+# Get the outcome of a step
+OUTCOME=$(buildkite-agent step get "outcome" --step "test-step")
+```
+
+### Update step attributes
+
+```bash
+# Update current step's label dynamically
+buildkite-agent step update "label" ":rocket: Deploying v${VERSION}"
+
+# Update another step
+buildkite-agent step update "label" ":hourglass: Waiting..." --step "pending-step"
+```
+
+### Cancel a step
+
+```bash
+# Cancel a specific step by key
+buildkite-agent step cancel --step "optional-step"
+```
+
+### Key flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--step` | current step | Step key or UUID to target |
+| `--build` | current build | Build UUID (for cross-build operations) |
+| `--format` | `string` | Output format for `get` |
+
+### Available step attributes
+
+| Attribute | Readable | Writable | Description |
+|-----------|----------|----------|-------------|
+| `label` | yes | yes | Step label displayed in UI |
+| `state` | yes | no | Current state (`running`, `passed`, `failed`, etc.) |
+| `outcome` | yes | no | Final outcome of the step |
+| `key` | yes | no | Step key identifier |
+
+## Distributed Locks
+
+Coordinate parallel jobs within a build using distributed mutex locks. Prevents race conditions when multiple jobs access shared resources.
+
+### Acquire / release pattern
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Acquire lock — blocks until available, returns a token
+token=$(buildkite-agent lock acquire "database-migration")
+
+# Critical section — only one job runs this at a time
+bundle exec rails db:migrate
+
+# Release lock — always release, even on failure
+buildkite-agent lock release "database-migration" "${token}"
+```
+
+Use a trap to ensure the lock is released on failure:
+
+```bash
+token=$(buildkite-agent lock acquire "shared-resource")
+trap 'buildkite-agent lock release "shared-resource" "${token}"' EXIT
+
+# Critical section
+run-exclusive-task.sh
+```
+
+### Do / done pattern (one-time setup)
+
+Run a setup task exactly once across all parallel jobs:
+
+```bash
+#!/bin/bash
+echo "+++ Setting up shared test environment"
+
+if [[ $(buildkite-agent lock do "test-env-setup") == "do" ]]; then
+  echo "Downloading test assets..."
+  curl -o /tmp/test-data.zip https://releases.example.com/data.zip
+  unzip /tmp/test-data.zip -d /tmp/shared-test-files/
+  buildkite-agent lock done "test-env-setup"
+else
+  echo "Assets already prepared by another job"
+fi
+
+# All jobs continue here
+run-tests.sh
+```
+
+### Get lock state
+
+```bash
+# Check current state of a lock (returns "do" or "done")
+STATE=$(buildkite-agent lock get "test-env-setup")
+```
+
+### Key flags
+
+| Subcommand | Flags | Description |
+|------------|-------|-------------|
+| `lock acquire <name>` | `--timeout` | Maximum wait time in seconds (0 = wait forever) |
+| `lock release <name> <token>` | — | Release with the token from `acquire` |
+| `lock do <name>` | — | Returns `do` if lock acquired, `done` if already completed |
+| `lock done <name>` | — | Mark a `do` lock as completed |
+| `lock get <name>` | — | Check lock state without acquiring |
+
+## Environment
+
+Inspect and modify the job's environment variables. Primarily useful for debugging lifecycle hooks and understanding what environment changes hooks made.
+
+### Dump all variables
+
+```bash
+# Output all environment variables as JSON
+buildkite-agent env dump
+
+# Pretty-print for readability
+buildkite-agent env dump | jq .
+```
+
+### Get a specific variable
+
+```bash
+# Get a single environment variable's value
+buildkite-agent env get "BUILDKITE_BRANCH"
+
+# Get multiple variables
+buildkite-agent env get "BUILDKITE_BRANCH" "BUILDKITE_BUILD_NUMBER"
+```
+
+### Set and unset variables
+
+```bash
+# Set an environment variable for subsequent hooks and the command
+buildkite-agent env set "DEPLOY_TARGET" "production"
+
+# Unset a variable
+buildkite-agent env unset "TEMPORARY_VAR"
+```
+
+### Key flags
+
+| Subcommand | Default | Description |
+|------------|---------|-------------|
+| `env dump` | JSON to stdout | Dump all environment variables |
+| `env get <keys...>` | — | Get one or more specific variables |
+| `env set <key> <value>` | — | Set a variable for subsequent phases |
+| `env unset <key>` | — | Remove a variable from subsequent phases |
+
+### Debugging hooks
+
+The `env dump` command is particularly useful in lifecycle hooks to see what prior hooks changed:
+
+```bash
+#!/bin/bash
+# .buildkite/hooks/pre-command
+echo "--- Environment after environment hook:"
+buildkite-agent env dump | jq 'keys'
+```
+
+> For agent lifecycle hooks and `buildkite-agent.cfg` configuration, see the **buildkite-platform-engineering** skill.
+
+## Secrets
+
+Retrieve cluster secrets at runtime from within job steps. Secrets retrieved this way are automatically added to the log redactor.
+
+### Basic usage
+
+```bash
+# Get a secret value
+SECRET_VAR=$(buildkite-agent secret get "deploy-key")
+
+# Write to a file
+buildkite-agent secret get "ssh-private-key" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+
+# Pass directly to a tool
+cli-tool --token "$(buildkite-agent secret get "api-token")"
+```
+
+### Multiple secrets
+
+```bash
+# Get multiple secrets in env format (for sourcing)
+buildkite-agent secret get --format env "deploy_key" "github_api_token"
+# Output:
+# DEPLOY_KEY="..."
+# GITHUB_API_TOKEN="..."
+
+# Source into current shell
+eval "$(buildkite-agent secret get --format env deploy_key github_api_token)"
+```
+
+### Key flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `string` | Output format: `string` (single secret) or `env` (multiple, KEY="value" pairs) |
+| `--skip-redaction` | `false` | Do not add the secret value to the log redactor |
+| `--job` | current job | Job ID context |
+
+### Automatic redaction
+
+By default, `secret get` automatically registers retrieved values with the log redactor. Any subsequent log output containing the secret value will be masked as `[REDACTED]`. Use `--skip-redaction` only when the value is not sensitive (e.g., a non-secret configuration value stored in the secrets backend).
+
+### Pipeline YAML shorthand
+
+For simple secret injection, the declarative `secrets:` key in pipeline YAML is more concise:
+
+```yaml
+steps:
+  - command: "deploy.sh"
+    secrets:
+      - deploy-key
+      - github-api-token
+```
+
+> For setting up cluster secrets, see the **buildkite-platform-engineering** skill. For the declarative `secrets:` pipeline YAML key, see the **buildkite-pipelines** skill.
+
+## Log Redaction
+
+Add values to the build log redactor at runtime so they are masked in all subsequent output. Use this for dynamically-retrieved secrets that were not declared via `secrets:` or `buildkite-agent secret get`.
+
+### Basic usage
+
+```bash
+# Fetch a token from an external source
+DYNAMIC_TOKEN=$(curl -s https://vault.example.com/token)
+
+# Register it with the redactor before using it
+echo "$DYNAMIC_TOKEN" | buildkite-agent redactor add
+
+# Now any log output containing the token value shows [REDACTED]
+echo "Using token: $DYNAMIC_TOKEN"
+# Output: Using token: [REDACTED]
+```
+
+### Multiple values
+
+```bash
+# Redact multiple values
+echo "$SECRET1" | buildkite-agent redactor add
+echo "$SECRET2" | buildkite-agent redactor add
+```
+
+### When to use redactor vs secret get
+
+| Scenario | Use |
+|----------|-----|
+| Secret stored in Buildkite cluster secrets | `buildkite-agent secret get` (auto-redacts) |
+| Secret from external vault (HashiCorp Vault, AWS SSM, etc.) | Fetch externally, then `buildkite-agent redactor add` |
+| Computed sensitive value (temporary token, derived key) | `buildkite-agent redactor add` |
+
+## Tool Signing
+
+Sign and verify pipeline step definitions for integrity checking. Ensures steps have not been tampered with between definition and execution.
+
+### Sign a pipeline
+
+```bash
+# Sign step configuration using a JWKS key
+buildkite-agent tool sign --jwks-file /etc/buildkite-agent/signing-key.json \
+  --step "command=make test" \
+  --step "plugins=docker#v5.12.0"
+```
+
+### Verify a signature
+
+```bash
+# Verify step signature
+buildkite-agent tool verify --jwks-file /etc/buildkite-agent/verification-key.json \
+  --step "command=make test"
+```
+
+### Key flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--jwks-file` | — | Path to JWKS key file for signing or verification |
+| `--jwks-key-id` | — | Key ID to use from the JWKS file |
+| `--step` | — | Step attributes to sign/verify (repeatable) |
+
+> For pipeline signing configuration and rollout strategy, see the **buildkite-secure-delivery** skill.
+
+## Common Mistakes
+
+| Mistake | What happens | Fix |
+|---------|-------------|-----|
+| Missing `--context` on `annotate` | Each call creates a new annotation instead of updating | Always pass `--context` with a stable identifier |
+| Using `--append` without matching `--context` | Append has no effect — creates a new annotation | Ensure `--context` matches the annotation to append to |
+| Forgetting to quote artifact glob patterns | Shell expands globs before `buildkite-agent` sees them | Always quote: `"dist/**/*"` not `dist/**/*` |
+| Reading `meta-data get` before the writing job completes | Key does not exist, command fails with non-zero exit | Use `depends_on` or `wait` to enforce ordering, or use `--default` |
+| Using `pipeline upload --replace` unintentionally | Removes all remaining steps in the build | Only use `--replace` when intentionally rebuilding the entire pipeline |
+| Not releasing locks on script failure | Lock held indefinitely, blocking other jobs | Use `trap ... EXIT` to release locks on any exit |
+| Passing `--audience` that doesn't match OIDC provider config | Token rejected by the target service | Audience must exactly match the provider's configured audience URL |
+| Using `--skip-redaction` with actual secrets | Secret values appear in plain text in build logs | Only use `--skip-redaction` for non-sensitive configuration values |
+| Calling `env set` expecting it to affect the current shell | Variable is set for subsequent hooks/phases, not the current script | Use `export VAR=value` for current-script variables; `env set` for cross-phase |
+| Uploading pipeline YAML with unescaped `$` in `--no-interpolation` mode off | Variables interpolated unexpectedly, producing malformed YAML | Use `--no-interpolation` when YAML contains literal `$` characters |
+
+## Additional Resources
+
+### Reference Files
+- **`references/flag-reference.md`** — Complete flag tables for all subcommands including upload, download, search, shasum, annotate, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor, and tool
+- **`references/patterns-and-recipes.md`** — Advanced multi-subcommand patterns: test failure annotation pipelines, cross-job state machines, OIDC-authenticated Docker push, parallel job coordination with locks, environment debugging
+
+## Further Reading
+
+- [Agent CLI — annotate](https://buildkite.com/docs/agent/v3/cli-annotate)
+- [Agent CLI — artifact](https://buildkite.com/docs/agent/v3/cli-artifact)
+- [Agent CLI — meta-data](https://buildkite.com/docs/agent/v3/cli-meta-data)
+- [Agent CLI — pipeline](https://buildkite.com/docs/agent/v3/cli-pipeline)
+- [Agent CLI — OIDC](https://buildkite.com/docs/agent/v3/cli-oidc)
+- [Agent CLI — lock](https://buildkite.com/docs/agent/v3/cli-lock)
+- [Managing secrets with Buildkite secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)
+- [Dynamic pipelines](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines)

--- a/skills/buildkite-agent-runtime/references/flag-reference.md
+++ b/skills/buildkite-agent-runtime/references/flag-reference.md
@@ -1,0 +1,417 @@
+# Buildkite Agent Runtime — Complete Flag Reference
+
+Exhaustive flag tables for every `buildkite-agent` subcommand used inside job steps. The SKILL.md contains the most common flags inline; this file has the full set.
+
+## annotate
+
+```
+buildkite-agent annotate [body] [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--style` | `-s` | `default` | Annotation style: `default`, `info`, `warning`, `error`, `success` |
+| `--context` | `-c` | random UUID | Unique context key — reusing replaces the annotation |
+| `--append` | — | `false` | Append content to existing annotation with same context |
+| `--priority` | — | `3` | Display priority (1-10), higher numbers shown first |
+| `--job` | — | current job | Job UUID to annotate |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--no-color` | — | `false` | Disable colored output |
+| `--debug` | — | `false` | Enable debug logging |
+
+Body can be passed as a positional argument, piped from stdin, or read from a file via redirection.
+
+## artifact upload
+
+```
+buildkite-agent artifact upload <pattern> [destination] [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--job` | — | `$BUILDKITE_JOB_ID` | Job UUID to associate artifacts with |
+| `--content-type` | — | auto-detected | MIME type for uploaded files |
+| `--glob` | — | — | Glob pattern (alternative to positional argument) |
+| `--follow-symlinks` | — | `false` | Follow symbolic links when resolving globs |
+| `--upload-skip-symlinks` | — | `false` | Skip symbolic links entirely |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Multiple glob patterns can be separated by `;` in the positional argument: `"logs/*.log;dist/**/*"`.
+
+## artifact download
+
+```
+buildkite-agent artifact download <query> <destination> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--step` | — | all steps | Step key or UUID to scope downloads to |
+| `--build` | — | current build | Build UUID to download from |
+| `--include-retried-jobs` | — | `false` | Include artifacts from retried job attempts |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Quote wildcard queries to prevent shell expansion: `"pkg/*.tar.gz"` not `pkg/*.tar.gz`.
+
+## artifact search
+
+```
+buildkite-agent artifact search <query> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--step` | — | all steps | Step key or UUID to scope search to |
+| `--build` | — | current build | Build UUID to search within |
+| `--format` | — | default | Output format template (e.g., `%p\n` for path per line) |
+| `--include-retried-jobs` | — | `false` | Include artifacts from retried job attempts |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## artifact shasum
+
+```
+buildkite-agent artifact shasum <query> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--sha256` | — | `false` | Return SHA-256 hash instead of SHA-1 |
+| `--step` | — | all steps | Step key or UUID to scope to |
+| `--build` | — | current build | Build UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+SHA-256 is only available for artifacts uploaded after SHA-256 support was added. Older artifacts only have SHA-1.
+
+## meta-data set
+
+```
+buildkite-agent meta-data set <key> [value] [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--job` | — | current job | Job UUID for context |
+| `--build` | — | current build | Build UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Value can be passed as second positional argument, piped from stdin, or redirected from a file. Value must be a non-empty string.
+
+## meta-data get
+
+```
+buildkite-agent meta-data get <key> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--default` | — | — | Default value if key does not exist (prevents non-zero exit) |
+| `--job` | — | current job | Job UUID for context |
+| `--build` | — | current build | Build UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Without `--default`, exits with a non-zero code if the key does not exist.
+
+## meta-data exists
+
+```
+buildkite-agent meta-data exists <key> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--job` | — | current job | Job UUID for context |
+| `--build` | — | current build | Build UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Returns exit code `0` if key exists, `100` if not.
+
+## meta-data keys
+
+```
+buildkite-agent meta-data keys [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--build` | — | current build | Build UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Outputs one key per line.
+
+## pipeline upload
+
+```
+buildkite-agent pipeline upload [file] [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--replace` | — | `false` | Replace remaining pipeline steps instead of appending |
+| `--no-interpolation` | — | `false` | Skip `$VARIABLE` interpolation in the uploaded YAML |
+| `--dry-run` | — | `false` | Output the parsed pipeline without uploading |
+| `--reject-secrets` | — | `false` | Reject upload if plain-text secrets are detected |
+| `--job` | — | current job | Job UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+If no file is specified, looks for `.buildkite/pipeline.yml`, `.buildkite/pipeline.json`, `buildkite.yml`, or `buildkite.json`. Pipeline is limited to 500 steps per upload.
+
+## oidc request-token
+
+```
+buildkite-agent oidc request-token [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--audience` | — | Buildkite endpoint | Target service URL for the token's `aud` claim |
+| `--lifetime` | — | `600` | Token lifetime in seconds |
+| `--claim` | — | — | Comma-separated optional claims to include (e.g., `organization_id,pipeline_id`) |
+| `--aws-session-tag` | — | — | Comma-separated claims to map as AWS session tags |
+| `--job` | — | current job | Job UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Token is printed to stdout. Pipe or capture with `$()`.
+
+## step get
+
+```
+buildkite-agent step get <attribute> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--step` | — | current step | Step key or UUID |
+| `--build` | — | current build | Build UUID |
+| `--format` | — | `string` | Output format |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## step update
+
+```
+buildkite-agent step update <attribute> <value> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--step` | — | current step | Step key or UUID |
+| `--build` | — | current build | Build UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## step cancel
+
+```
+buildkite-agent step cancel [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--step` | — | current step | Step key or UUID to cancel |
+| `--build` | — | current build | Build UUID |
+| `--force` | — | `false` | Force cancel even if the step is running |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## lock acquire
+
+```
+buildkite-agent lock acquire <name> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--timeout` | — | `0` (wait forever) | Maximum wait time in seconds |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Returns a lock token (string) that must be passed to `lock release`.
+
+## lock release
+
+```
+buildkite-agent lock release <name> <token> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## lock do
+
+```
+buildkite-agent lock do <name> [options...]
+```
+
+Returns `do` if the lock was acquired (caller should do the work, then call `lock done`). Returns `done` if another process already completed the work.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## lock done
+
+```
+buildkite-agent lock done <name> [options...]
+```
+
+Marks a `do`-style lock as completed. Other callers of `lock do` will now receive `done`.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## lock get
+
+```
+buildkite-agent lock get <name> [options...]
+```
+
+Returns the current state of a `do`-style lock: `do` (not yet completed) or `done` (completed).
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+## env dump
+
+```
+buildkite-agent env dump [options...]
+```
+
+Outputs all environment variables as JSON to stdout.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--format` | — | `json` | Output format |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--debug` | — | `false` | Enable debug logging |
+
+## env get
+
+```
+buildkite-agent env get <keys...> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--format` | — | `json` | Output format |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--debug` | — | `false` | Enable debug logging |
+
+Accepts one or more variable names as positional arguments.
+
+## env set
+
+```
+buildkite-agent env set <key> <value> [options...]
+```
+
+Sets an environment variable for subsequent hook phases and the command phase. Does not affect the current running script.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--debug` | — | `false` | Enable debug logging |
+
+## env unset
+
+```
+buildkite-agent env unset <key> [options...]
+```
+
+Removes an environment variable from subsequent hook phases.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--debug` | — | `false` | Enable debug logging |
+
+## secret get
+
+```
+buildkite-agent secret get <key...> [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--format` | — | `string` | Output format: `string` (single secret), `env` (KEY="value" pairs) |
+| `--skip-redaction` | — | `false` | Do not register the value with the log redactor |
+| `--job` | — | current job | Job UUID |
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--endpoint` | — | from config | Agent API endpoint |
+| `--debug` | — | `false` | Enable debug logging |
+
+Accepts one or more secret names. With `--format env`, outputs `KEY="value"` pairs suitable for `eval` or `source`.
+
+## redactor add
+
+```
+buildkite-agent redactor add [options...]
+```
+
+Reads the value to redact from stdin. All subsequent log output containing this value will show `[REDACTED]`.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--agent-access-token` | — | from env | Agent registration token |
+| `--debug` | — | `false` | Enable debug logging |
+
+## tool sign
+
+```
+buildkite-agent tool sign [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--jwks-file` | — | — | Path to JWKS key file for signing |
+| `--jwks-key-id` | — | — | Key ID to use from the JWKS file |
+| `--step` | — | — | Step attribute to sign (repeatable, format: `key=value`) |
+| `--debug` | — | `false` | Enable debug logging |
+
+## tool verify
+
+```
+buildkite-agent tool verify [options...]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--jwks-file` | — | — | Path to JWKS key file for verification |
+| `--jwks-key-id` | — | — | Key ID to use from the JWKS file |
+| `--step` | — | — | Step attribute to verify (repeatable, format: `key=value`) |
+| `--debug` | — | `false` | Enable debug logging |

--- a/skills/buildkite-agent-runtime/references/patterns-and-recipes.md
+++ b/skills/buildkite-agent-runtime/references/patterns-and-recipes.md
@@ -1,0 +1,555 @@
+# Patterns and Recipes
+
+Advanced usage patterns combining multiple `buildkite-agent` runtime subcommands. Each recipe shows a real-world scenario with complete, copy-pasteable code.
+
+---
+
+## Test failure annotation with artifact links
+
+Annotate the build page with a formatted test failure summary and link to the uploaded report.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Run tests and capture output
+if ! make test 2>&1 | tee test-output.txt; then
+  # Upload the full test output as an artifact
+  buildkite-agent artifact upload "test-output.txt"
+
+  # Count failures for the summary
+  FAIL_COUNT=$(grep -c "FAIL" test-output.txt || true)
+
+  # Create a rich annotation with failure details and artifact link
+  buildkite-agent annotate --style "error" --context "test-failures" <<EOF
+## :x: ${FAIL_COUNT} test(s) failed
+
+<details>
+<summary>Failure summary (click to expand)</summary>
+
+\`\`\`
+$(grep -A 3 "FAIL" test-output.txt | head -50)
+\`\`\`
+
+</details>
+
+Full output: <a href="artifact://test-output.txt">test-output.txt</a>
+EOF
+  exit 1
+fi
+
+# Success annotation
+buildkite-agent annotate ":white_check_mark: All tests passed" \
+  --style "success" --context "test-failures"
+```
+
+**Pipeline YAML:**
+
+```yaml
+steps:
+  - label: ":test_tube: Tests"
+    command: ".buildkite/scripts/test-with-annotations.sh"
+    artifact_paths: "test-output.txt"
+```
+
+---
+
+## Progressive annotation with parallel jobs
+
+Each parallel job appends its results to a shared annotation. The final step summarizes.
+
+```yaml
+steps:
+  - label: ":rspec: Tests %n"
+    command: ".buildkite/scripts/test-parallel.sh"
+    parallelism: 4
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":bar_chart: Summary"
+    command: ".buildkite/scripts/test-summary.sh"
+```
+
+**test-parallel.sh:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+JOB_INDEX="${BUILDKITE_PARALLEL_JOB}"
+TOTAL="${BUILDKITE_PARALLEL_JOB_COUNT}"
+
+# Run this job's slice of the test suite
+bundle exec rspec $(./scripts/split-tests.sh "$JOB_INDEX" "$TOTAL") \
+  --format json --out "results-${JOB_INDEX}.json" \
+  --format progress || true
+
+# Upload results as artifact
+buildkite-agent artifact upload "results-${JOB_INDEX}.json"
+
+# Store pass/fail in meta-data
+if jq -e '.summary.failure_count == 0' "results-${JOB_INDEX}.json" > /dev/null; then
+  buildkite-agent meta-data set "test-result-${JOB_INDEX}" "passed"
+else
+  FAILURES=$(jq '.summary.failure_count' "results-${JOB_INDEX}.json")
+  buildkite-agent meta-data set "test-result-${JOB_INDEX}" "failed:${FAILURES}"
+fi
+
+# Append this job's result to the shared annotation
+buildkite-agent annotate --style "info" --context "test-progress" --append <<EOF
+- Job ${JOB_INDEX}/$((TOTAL - 1)): $(buildkite-agent meta-data get "test-result-${JOB_INDEX}")
+EOF
+```
+
+**test-summary.sh:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+TOTAL="${BUILDKITE_PARALLEL_JOB_COUNT:-4}"
+PASSED=0
+FAILED=0
+FAILURE_DETAILS=""
+
+for i in $(seq 0 $((TOTAL - 1))); do
+  RESULT=$(buildkite-agent meta-data get "test-result-${i}")
+  if [[ "$RESULT" == "passed" ]]; then
+    ((PASSED++))
+  else
+    ((FAILED++))
+    COUNT="${RESULT#failed:}"
+    FAILURE_DETAILS="${FAILURE_DETAILS}\n- Job ${i}: ${COUNT} failures"
+  fi
+done
+
+if [[ "$FAILED" -eq 0 ]]; then
+  buildkite-agent annotate --style "success" --context "test-summary" <<EOF
+## :white_check_mark: All ${PASSED} test jobs passed
+EOF
+else
+  buildkite-agent annotate --style "error" --context "test-summary" <<EOF
+## :x: ${FAILED}/${TOTAL} test jobs had failures
+${FAILURE_DETAILS}
+EOF
+  exit 1
+fi
+```
+
+---
+
+## Cross-job state machine with meta-data and pipeline upload
+
+A build where early steps determine what runs later by setting meta-data and dynamically uploading pipelines.
+
+```yaml
+steps:
+  - label: ":mag: Analyze"
+    command: ".buildkite/scripts/analyze.sh"
+
+  - wait
+
+  - label: ":pipeline: Plan"
+    command: ".buildkite/scripts/plan.sh"
+```
+
+**analyze.sh:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Detect what changed
+CHANGED=$(git diff --name-only HEAD~1)
+
+# Classify changes and store as meta-data
+if echo "$CHANGED" | grep -q "^src/"; then
+  buildkite-agent meta-data set "needs-build" "true"
+else
+  buildkite-agent meta-data set "needs-build" "false"
+fi
+
+if echo "$CHANGED" | grep -q "^test/\|^spec/"; then
+  buildkite-agent meta-data set "needs-test" "true"
+else
+  buildkite-agent meta-data set "needs-test" "false"
+fi
+
+if echo "$CHANGED" | grep -qE "^(Dockerfile|docker-compose)"; then
+  buildkite-agent meta-data set "needs-docker" "true"
+else
+  buildkite-agent meta-data set "needs-docker" "false"
+fi
+```
+
+**plan.sh:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+NEEDS_BUILD=$(buildkite-agent meta-data get "needs-build")
+NEEDS_TEST=$(buildkite-agent meta-data get "needs-test")
+NEEDS_DOCKER=$(buildkite-agent meta-data get "needs-docker")
+
+# Build pipeline YAML based on analysis results
+PIPELINE="steps:"
+
+if [[ "$NEEDS_BUILD" == "true" ]]; then
+  PIPELINE="${PIPELINE}
+  - label: ':hammer: Build'
+    key: 'build'
+    command: 'make build'"
+fi
+
+if [[ "$NEEDS_TEST" == "true" ]]; then
+  PIPELINE="${PIPELINE}
+  - label: ':test_tube: Test'
+    key: 'test'
+    command: 'make test'
+    depends_on: 'build'"
+fi
+
+if [[ "$NEEDS_DOCKER" == "true" ]]; then
+  PIPELINE="${PIPELINE}
+  - label: ':docker: Docker Build'
+    key: 'docker'
+    command: 'make docker-build'
+    depends_on: 'build'"
+fi
+
+# If nothing changed that we care about, skip
+if [[ "$PIPELINE" == "steps:" ]]; then
+  PIPELINE="steps:
+  - label: ':white_check_mark: Nothing to do'
+    command: 'echo No relevant changes detected'"
+fi
+
+echo "$PIPELINE" | buildkite-agent pipeline upload
+```
+
+---
+
+## Block step to meta-data to trigger
+
+Collect user input via a block step, read the values from meta-data, and trigger a downstream pipeline.
+
+```yaml
+steps:
+  - block: ":rocket: Deploy"
+    prompt: "Choose deploy target"
+    fields:
+      - key: "deploy-env"
+        text: "Environment"
+        default: "staging"
+        hint: "staging or production"
+      - key: "deploy-version"
+        text: "Version tag"
+        required: true
+
+  - label: ":pipeline: Trigger deploy"
+    command: ".buildkite/scripts/trigger-deploy.sh"
+```
+
+**trigger-deploy.sh:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Block step field values are stored as meta-data automatically
+ENV=$(buildkite-agent meta-data get "deploy-env")
+VERSION=$(buildkite-agent meta-data get "deploy-version")
+
+buildkite-agent annotate "Deploying **${VERSION}** to **${ENV}**" \
+  --style "info" --context "deploy-trigger"
+
+buildkite-agent pipeline upload <<YAML
+steps:
+  - trigger: "deploy-service"
+    label: ":rocket: Deploy ${VERSION} to ${ENV}"
+    build:
+      branch: "${BUILDKITE_BRANCH}"
+      message: "Deploy ${VERSION} to ${ENV}"
+      meta_data:
+        deploy-env: "${ENV}"
+        deploy-version: "${VERSION}"
+YAML
+```
+
+---
+
+## OIDC-authenticated Docker push with secret redaction
+
+Authenticate to a registry using OIDC, build and push an image, then annotate the build with the image tag.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+REGISTRY="packages.buildkite.com/my-org/my-registry"
+IMAGE_TAG="${REGISTRY}/myapp:${BUILDKITE_BUILD_NUMBER}"
+
+# Request OIDC token and authenticate with the registry
+buildkite-agent oidc request-token \
+  --audience "https://${REGISTRY}" \
+  --lifetime 300 \
+  | docker login "${REGISTRY}" -u buildkite --password-stdin
+
+# Build and push
+docker build -t "${IMAGE_TAG}" .
+docker push "${IMAGE_TAG}"
+
+# Store the image tag for downstream jobs
+buildkite-agent meta-data set "image-tag" "${IMAGE_TAG}"
+
+# Annotate with the published image
+buildkite-agent annotate --style "success" --context "docker-push" <<EOF
+:docker: Published \`${IMAGE_TAG}\`
+EOF
+```
+
+---
+
+## OIDC with AWS role assumption
+
+Request an OIDC token, exchange it for AWS credentials using STS, and redact the temporary credentials.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Request OIDC token with AWS session tags
+OIDC_TOKEN=$(buildkite-agent oidc request-token \
+  --audience "sts.amazonaws.com" \
+  --lifetime 300 \
+  --aws-session-tag "organization_slug,pipeline_slug")
+
+# Exchange for AWS credentials
+AWS_CREDS=$(aws sts assume-role-with-web-identity \
+  --role-arn "arn:aws:iam::123456789012:role/buildkite-deploy" \
+  --role-session-name "buildkite-${BUILDKITE_BUILD_NUMBER}" \
+  --web-identity-token "$OIDC_TOKEN" \
+  --output json)
+
+# Extract and redact credentials
+export AWS_ACCESS_KEY_ID=$(echo "$AWS_CREDS" | jq -r '.Credentials.AccessKeyId')
+export AWS_SECRET_ACCESS_KEY=$(echo "$AWS_CREDS" | jq -r '.Credentials.SecretAccessKey')
+export AWS_SESSION_TOKEN=$(echo "$AWS_CREDS" | jq -r '.Credentials.SessionToken')
+
+echo "$AWS_SECRET_ACCESS_KEY" | buildkite-agent redactor add
+echo "$AWS_SESSION_TOKEN" | buildkite-agent redactor add
+
+# Now use AWS commands — credentials are redacted in logs
+aws s3 cp build/app.tar.gz s3://deploy-bucket/releases/
+```
+
+---
+
+## Parallel job coordination with locks
+
+Multiple parallel jobs share a database, but only one should run migrations. Use `lock do/done` to ensure exactly-once execution.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# One-time database migration across parallel test jobs
+echo "+++ Database setup"
+if [[ $(buildkite-agent lock do "db-migrate") == "do" ]]; then
+  echo "Running database migrations..."
+  bundle exec rails db:migrate
+  buildkite-agent meta-data set "db-ready" "true"
+  buildkite-agent lock done "db-migrate"
+else
+  echo "Migrations already run by another job, waiting for completion..."
+  # Poll until the migrating job marks the DB as ready
+  while ! buildkite-agent meta-data exists "db-ready" 2>/dev/null; do
+    sleep 2
+  done
+fi
+
+echo "+++ Running tests"
+bundle exec rspec $(./scripts/split-tests.sh "$BUILDKITE_PARALLEL_JOB" "$BUILDKITE_PARALLEL_JOB_COUNT")
+```
+
+---
+
+## Exclusive deploy with acquire/release locks
+
+Only one deploy runs at a time across parallel jobs, with guaranteed lock release via trap.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+echo "+++ Acquiring deploy lock"
+TOKEN=$(buildkite-agent lock acquire "deploy-production")
+trap 'buildkite-agent lock release "deploy-production" "${TOKEN}"' EXIT
+
+echo "+++ Deploying"
+buildkite-agent step update "label" ":rocket: Deploying to production..."
+
+./scripts/deploy.sh
+
+buildkite-agent step update "label" ":white_check_mark: Deployed to production"
+buildkite-agent annotate "Deployed at $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --style "success" --context "deploy"
+```
+
+---
+
+## Environment debugging in hooks
+
+Debug what lifecycle hooks are doing to the environment by dumping state at each stage.
+
+**environment hook** (`.buildkite/hooks/environment`):
+
+```bash
+#!/bin/bash
+
+# Set up shared variables
+export APP_ENV="test"
+export DATABASE_URL="postgres://localhost:5432/test"
+
+# Dump environment state after this hook
+if [[ "${BUILDKITE_AGENT_DEBUG:-}" == "true" ]]; then
+  buildkite-agent env dump > /tmp/env-after-environment.json
+fi
+```
+
+**pre-command hook** (`.buildkite/hooks/pre-command`):
+
+```bash
+#!/bin/bash
+
+# Inject secrets
+export SECRET_KEY=$(buildkite-agent secret get "SECRET_KEY")
+
+if [[ "${BUILDKITE_AGENT_DEBUG:-}" == "true" ]]; then
+  buildkite-agent env dump > /tmp/env-after-pre-command.json
+
+  # Compare with environment hook (keys only — don't log values)
+  echo "New vars added by pre-command hook:"
+  diff <(jq -r 'keys[]' /tmp/env-after-environment.json) \
+       <(jq -r 'keys[]' /tmp/env-after-pre-command.json) \
+    | grep "^>" || echo "(none)"
+fi
+```
+
+---
+
+## Dynamic annotation dashboard
+
+Build a live-updating dashboard annotation that multiple steps contribute to throughout a build.
+
+```bash
+# Step 1: Initialize the dashboard
+buildkite-agent annotate --style "info" --context "dashboard" <<'EOF'
+## Build Dashboard
+| Stage | Status | Duration |
+|-------|--------|----------|
+EOF
+
+# Helper function (include in each step that updates the dashboard)
+update_dashboard() {
+  local stage="$1" status="$2" duration="$3"
+  buildkite-agent annotate --style "info" --context "dashboard" --append <<EOF
+| ${stage} | ${status} | ${duration} |
+EOF
+}
+```
+
+**Usage in each step:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source .buildkite/scripts/dashboard-helpers.sh
+
+START=$(date +%s)
+make lint
+DURATION=$(($(date +%s) - START))
+
+update_dashboard "Lint" ":white_check_mark:" "${DURATION}s"
+```
+
+---
+
+## Secrets from external vault with redaction
+
+Fetch secrets from HashiCorp Vault and redact them from build logs.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Authenticate to Vault using Buildkite OIDC
+VAULT_TOKEN=$(buildkite-agent oidc request-token --audience "https://vault.internal" \
+  | vault write -field=token auth/jwt/login role=buildkite jwt=-)
+
+echo "$VAULT_TOKEN" | buildkite-agent redactor add
+
+# Fetch application secrets
+DB_PASSWORD=$(VAULT_TOKEN="$VAULT_TOKEN" vault kv get -field=password secret/myapp/db)
+API_KEY=$(VAULT_TOKEN="$VAULT_TOKEN" vault kv get -field=key secret/myapp/api)
+
+# Redact both values
+echo "$DB_PASSWORD" | buildkite-agent redactor add
+echo "$API_KEY" | buildkite-agent redactor add
+
+# Export for use (values are now redacted in any log output)
+export DB_PASSWORD API_KEY
+
+# Use them safely
+./scripts/deploy.sh
+```
+
+---
+
+## Artifact chain across builds
+
+Upload artifacts in a build step, then download them in a triggered child pipeline.
+
+**Parent pipeline step:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Build the artifact
+make build
+buildkite-agent artifact upload "dist/app.tar.gz"
+
+# Store the build ID so the child pipeline can reference it
+buildkite-agent meta-data set "artifact-build-id" "${BUILDKITE_BUILD_ID}"
+
+# Trigger child pipeline, passing the build ID
+buildkite-agent pipeline upload <<YAML
+steps:
+  - trigger: "deploy-pipeline"
+    label: ":rocket: Deploy"
+    build:
+      message: "Deploy from build ${BUILDKITE_BUILD_NUMBER}"
+      meta_data:
+        parent-build-id: "${BUILDKITE_BUILD_ID}"
+YAML
+```
+
+**Child pipeline step:**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Get parent build ID from meta-data (passed via trigger step)
+PARENT_BUILD=$(buildkite-agent meta-data get "parent-build-id")
+
+# Download artifact from parent build
+buildkite-agent artifact download "dist/app.tar.gz" . --build "${PARENT_BUILD}"
+
+# Deploy it
+tar xzf dist/app.tar.gz
+./scripts/deploy.sh
+```

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -1,14 +1,665 @@
 ---
 name: buildkite-cli
 description: >
-  Covers the Buildkite CLI (bk) for interacting with builds, jobs, pipelines,
-  and artifacts from the terminal. Use when running bk build create, bk build
-  list, bk job log, bk job retry, bk pipeline commands, bk secret management,
-  bk artifact download/upload, or bk auth login. Also use when the user wants
-  to trigger builds, inspect job logs, manage secrets, or interact with
-  Buildkite from the command line.
+  This skill should be used when the user asks to "trigger a build",
+  "check build status", "watch a build", "view build logs", "retry a build",
+  "cancel a build", "list builds", "download artifacts", "upload artifacts",
+  "manage secrets", "create a pipeline", "list pipelines", or
+  "interact with Buildkite from the command line".
+  Also use when the user mentions bk commands, bk build, bk job, bk pipeline,
+  bk secret, bk artifact, bk cluster, bk package, bk auth, bk configure,
+  bk use, bk init, bk api, or asks about Buildkite CLI installation,
+  terminal-based Buildkite workflows, or command-line CI/CD operations.
 ---
 
 # Buildkite CLI
 
-<!-- TODO: Write skill content. Read CONVENTIONS.md and references/depot-ci-skill.md first. -->
+The Buildkite CLI (`bk`) provides terminal access to builds, jobs, pipelines, secrets, artifacts, clusters, and packages. Use it to trigger builds, tail logs, manage secrets, and automate CI/CD workflows without leaving the command line.
+
+## Quick Start
+
+```bash
+# Install
+brew tap buildkite/buildkite && brew install buildkite/buildkite/bk
+
+# Authenticate
+bk configure
+
+# Trigger a build on the current branch
+bk build create --pipeline my-app
+
+# Watch it run
+bk build watch 42 --pipeline my-app
+
+# View logs for a failed job
+bk job log <job-id> --pipeline my-app --build 42
+```
+
+## Installation
+
+### Homebrew (macOS and Linux)
+
+```bash
+brew tap buildkite/buildkite
+brew install buildkite/buildkite/bk
+```
+
+### Binary download
+
+Download pre-built binaries from the [GitHub releases page](https://github.com/buildkite/cli/releases). Extract and place the `bk` binary on the system PATH.
+
+### Shell completion
+
+Generate autocompletion scripts for the current shell:
+
+```bash
+# Bash
+bk completion bash > /etc/bash_completion.d/bk
+
+# Zsh
+bk completion zsh > "${fpath[1]}/_bk"
+
+# Fish
+bk completion fish > ~/.config/fish/completions/bk.fish
+```
+
+### Verify installation
+
+```bash
+bk --version
+```
+
+## Authentication
+
+### Initial setup
+
+Run `bk configure` to set the organization slug and API access token. This creates `$HOME/.config/bk.yaml` on first run.
+
+```bash
+bk configure
+```
+
+Pass values non-interactively for automation:
+
+```bash
+bk configure --org my-org --token "$BUILDKITE_API_TOKEN"
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--org` | | — | Organization slug |
+| `--token` | | — | API access token (literal value or environment variable) |
+
+### Token creation
+
+1. Open Buildkite > user avatar > **Personal Settings** > **API Access Tokens**
+2. Select **New API Access Token**
+3. Grant scopes: `read_builds`, `write_builds`, `read_pipelines`, `read_artifacts` at minimum
+4. Copy the token and pass it to `bk configure`
+
+### Auth commands (v3.31+)
+
+Starting in v3.31, `bk auth` provides structured authentication management with system keychain storage.
+
+```bash
+# Login (stores credentials in system keychain)
+bk auth login
+
+# Check current authentication status
+bk auth status
+
+# Switch between authenticated organizations
+bk auth switch
+
+# Clear keychain credentials
+bk auth logout
+
+# Clear all keychain configurations
+bk auth logout --all
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `login` | Authenticate and store credentials in system keychain |
+| `status` | Display current authentication state |
+| `switch` | Switch between authenticated organizations |
+| `logout` | Clear stored credentials (`--all` removes all) |
+
+### Organization switching
+
+Switch the active organization for subsequent commands:
+
+```bash
+# Switch to a specific org
+bk use my-other-org
+
+# Interactive selection (if multiple orgs configured)
+bk use
+```
+
+## Builds
+
+Manage pipeline builds — create, view, list, cancel, retry, and watch.
+
+### Create a build
+
+```bash
+# Build the current branch and commit
+bk build create --pipeline my-app
+
+# Build a specific branch and commit
+bk build create --pipeline my-app --branch feature/auth --commit abc1234
+
+# Build with a custom message
+bk build create --pipeline my-app --message "Deploy v2.1.0"
+
+# Build with environment variables
+bk build create --pipeline my-app --env "DEPLOY_ENV=staging"
+
+# Build with metadata
+bk build create --pipeline my-app --metadata "release-version=2.1.0"
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+| `--branch` | `-b` | current branch | Git branch to build |
+| `--commit` | `-c` | HEAD | Git commit SHA |
+| `--message` | `-m` | — | Build message |
+| `--env` | `-e` | — | Environment variables (repeatable: `-e K=V -e K2=V2`) |
+| `--metadata` | | — | Build metadata key-value pairs (repeatable) |
+
+> If the Buildkite MCP server is available, use the `create_build` tool instead for direct access without shell execution.
+
+### View a build
+
+```bash
+# View build by number
+bk build view 42 --pipeline my-app
+
+# View the latest build
+bk build view --pipeline my-app
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+
+> If the Buildkite MCP server is available, use the `get_build` tool instead.
+
+### List builds
+
+```bash
+# List recent builds for a pipeline
+bk build list --pipeline my-app
+
+# List only failed builds
+bk build list --pipeline my-app --state failed
+
+# List builds for a specific branch
+bk build list --pipeline my-app --branch main
+
+# List builds across the entire organization
+bk build list
+
+# Machine-readable output
+bk build list --pipeline my-app --output json
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (omit for org-wide listing) |
+| `--branch` | `-b` | — | Filter by branch |
+| `--state` | `-s` | — | Filter by state: `running`, `scheduled`, `passed`, `failed`, `blocked`, `canceled`, `canceling`, `skipped`, `not_run`, `finished` |
+| `--output` | `-o` | `text` | Output format: `text`, `json` |
+
+> If the Buildkite MCP server is available, use the `list_builds` tool instead.
+
+### Watch a build
+
+Stream real-time build progress to the terminal. Blocks until the build completes or is canceled.
+
+```bash
+bk build watch 42 --pipeline my-app
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+
+### Cancel a build
+
+```bash
+bk build cancel 42 --pipeline my-app
+```
+
+The build must be in a `scheduled`, `running`, or `failing` state. Attempting to cancel a completed build returns an error.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+
+### Retry a build
+
+```bash
+# Retry (rebuild) a specific build
+bk build retry 42 --pipeline my-app
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+
+### Download build resources
+
+```bash
+bk build download 42 --pipeline my-app
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+
+### Build workflow: trigger and watch
+
+Combine `create` and `watch` for a complete trigger-and-follow workflow:
+
+```bash
+# Trigger a build and immediately stream progress
+bk build create --pipeline my-app --branch main && bk build watch --pipeline my-app
+```
+
+## Jobs
+
+Manage individual jobs within a build — view logs, retry failures, cancel running jobs.
+
+### View job logs
+
+```bash
+# View logs for a specific job
+bk job log <job-id> --pipeline my-app --build 42
+
+# Tail logs in real-time (follow mode)
+bk job log <job-id> --pipeline my-app --build 42 --follow
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+| `--build` | `-b` | — | Build number (required) |
+| `--follow` | `-f` | `false` | Stream logs in real-time |
+
+> If the Buildkite MCP server is available, use the `read_logs` or `tail_logs` tools instead.
+
+### Retry a job
+
+Retry a failed, timed-out, or canceled job. Each job ID can only be retried once — subsequent retries must use the new job ID returned by the first retry.
+
+```bash
+bk job retry <job-id> --pipeline my-app --build 42
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+| `--build` | `-b` | — | Build number (required) |
+
+The job must be in `failed`, `timed_out`, or `canceled` state (or have `permit_on_passed: true` in retry config).
+
+### Cancel a job
+
+```bash
+bk job cancel <job-id> --pipeline my-app --build 42
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+| `--build` | `-b` | — | Build number (required) |
+
+### Reprioritize a job
+
+Change priority of a scheduled (not yet running) job:
+
+```bash
+bk job reprioritize <job-id> --pipeline my-app --build 42 --priority 10
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+| `--build` | `-b` | — | Build number (required) |
+| `--priority` | | `0` | Priority value (higher runs first) |
+
+### Debugging workflow: find failures and read logs
+
+```bash
+# Find failed builds
+bk build list --pipeline my-app --state failed
+
+# View the build to identify which jobs failed
+bk build view 42 --pipeline my-app
+
+# Read logs for the failed job
+bk job log <job-id> --pipeline my-app --build 42
+```
+
+## Pipelines
+
+Manage pipeline configuration — list, create, and update pipelines.
+
+### List pipelines
+
+```bash
+# List all pipelines in the organization
+bk pipeline list
+
+# Machine-readable output
+bk pipeline list --output json
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--output` | `-o` | `text` | Output format: `text`, `json` |
+
+> If the Buildkite MCP server is available, use the `list_pipelines` tool instead.
+
+### Create a pipeline
+
+```bash
+bk pipeline create --name "My App" --repository "git@github.com:org/my-app.git"
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--name` | `-n` | — | Pipeline name (required) |
+| `--repository` | `-r` | — | Git repository URL (required) |
+| `--cluster` | | — | Cluster UUID to assign the pipeline to |
+| `--description` | `-d` | — | Pipeline description |
+
+> If the Buildkite MCP server is available, use the `create_pipeline` tool instead.
+
+> For pipeline YAML configuration after creation, see the **buildkite-pipelines** skill.
+
+### Update a pipeline
+
+```bash
+bk pipeline update my-app --description "Production application pipeline"
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--description` | `-d` | — | Updated description |
+| `--repository` | `-r` | — | Updated repository URL |
+
+> If the Buildkite MCP server is available, use the `update_pipeline` tool instead.
+
+## Secrets
+
+Manage cluster-scoped secrets for pipelines. Secrets are encrypted and accessible to all agents within a cluster.
+
+> For using secrets inside pipeline YAML (`secrets:` key) and inside job steps (`buildkite-agent secret get`), see the **buildkite-pipelines** skill and **buildkite-agent-runtime** skill respectively.
+
+### Create a secret
+
+```bash
+# Create a secret (interactive prompt for value)
+bk secret create MY_SECRET --cluster my-cluster
+
+# Create with an inline value
+bk secret create MY_SECRET --cluster my-cluster --value "$TOKEN"
+
+# Create with a description
+bk secret create DOCKER_PASSWORD --cluster my-cluster --value "$DOCKER_PWD" --description "Docker Hub credentials"
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--cluster` | | — | Cluster UUID or slug (required) |
+| `--value` | | — | Secret value (omit for interactive prompt) |
+| `--description` | `-d` | — | Human-readable description |
+
+**Naming rules:**
+- Keys must contain only letters, numbers, and underscores
+- Keys cannot begin with `buildkite` or `bk` (case-insensitive)
+- Exception: `BUILDKITE_API_TOKEN` is allowed
+
+**Credential safety:** Prefer interactive prompts over inline `--value` flags. When automation requires inline values, pass via environment variable reference (`--value "$TOKEN"`) rather than literal strings. Never hardcode secrets in scripts or command history.
+
+### List secrets
+
+```bash
+# List all secrets in a cluster
+bk secret list --cluster my-cluster
+
+# Machine-readable output
+bk secret list --cluster my-cluster --output json
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--cluster` | | — | Cluster UUID or slug (required) |
+| `--output` | `-o` | `text` | Output format: `text`, `json` |
+
+Secret values are never displayed — only names, descriptions, and metadata.
+
+### Update a secret
+
+```bash
+bk secret update MY_SECRET --cluster my-cluster --value "$NEW_TOKEN"
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--cluster` | | — | Cluster UUID or slug (required) |
+| `--value` | | — | New secret value |
+| `--description` | `-d` | — | Updated description |
+
+### Delete a secret
+
+```bash
+bk secret delete MY_SECRET --cluster my-cluster
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--cluster` | | — | Cluster UUID or slug (required) |
+
+### Secret access control
+
+Secrets are scoped to a cluster. All agents and pipelines within that cluster can access the secret. Secrets created by cluster maintainers and organization administrators only. Control which pipelines can access specific secrets through agent access policies.
+
+> For cluster creation and management, see the **buildkite-platform-engineering** skill.
+
+## Artifacts
+
+Upload and download build artifacts from the terminal.
+
+### Download artifacts
+
+```bash
+# Download all artifacts from a build
+bk artifact download --pipeline my-app --build 42
+
+# Download artifacts matching a glob pattern
+bk artifact download "dist/*.tar.gz" --pipeline my-app --build 42
+
+# Download to a specific directory
+bk artifact download "coverage/**/*" --pipeline my-app --build 42 --destination ./reports
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+| `--build` | `-b` | — | Build number (required) |
+| `--destination` | `-d` | `.` | Download destination directory |
+| `--job` | `-j` | — | Filter by job ID |
+
+> If the Buildkite MCP server is available, use the `list_artifacts_for_build` and `get_artifact` tools instead.
+
+### Upload artifacts
+
+```bash
+# Upload files matching a glob pattern
+bk artifact upload "dist/**/*" --pipeline my-app --build 42 --job <job-id>
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--pipeline` | `-p` | — | Pipeline slug (required) |
+| `--build` | `-b` | — | Build number (required) |
+| `--job` | `-j` | — | Job ID (required) |
+
+**Cluster constraint:** Pipelines associated with one cluster cannot access artifacts from another cluster unless explicitly allowed by cluster artifact access rules.
+
+> For uploading artifacts from within a running job step, use `buildkite-agent artifact upload` — see the **buildkite-agent-runtime** skill. For declaring artifact paths in pipeline YAML (`artifact_paths:`), see the **buildkite-pipelines** skill.
+
+## Clusters
+
+Manage organization clusters from the terminal.
+
+```bash
+# List clusters
+bk cluster list
+
+# View cluster details
+bk cluster view <cluster-slug>
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--output` | `-o` | `text` | Output format: `text`, `json` |
+
+> For cluster creation, queue management, hosted agent configuration, and infrastructure provisioning, see the **buildkite-platform-engineering** skill.
+
+## Packages
+
+Manage packages in Buildkite Package Registries.
+
+```bash
+# List package registries
+bk package list
+
+# Push a package
+bk package push <file> --registry my-registry
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--registry` | `-r` | — | Registry slug (required for push) |
+| `--output` | `-o` | `text` | Output format: `text`, `json` |
+
+Supports Docker images, npm packages, Debian packages, RPM packages, and generic file uploads. Push to Buildkite Package Registries, ECR, GAR, Artifactory, and ACR.
+
+> For OIDC-based authentication to package registries (no static credentials), see the **buildkite-secure-delivery** skill.
+
+## Raw API Access
+
+Make direct REST or GraphQL API calls from the terminal using `bk api`. Useful for operations not covered by dedicated subcommands.
+
+### REST API
+
+```bash
+# GET request
+bk api /organizations/my-org/pipelines
+
+# POST request with JSON body
+bk api --method POST /organizations/my-org/pipelines --data '{
+  "name": "New Pipeline",
+  "repository": "git@github.com:org/repo.git"
+}'
+
+# PUT request
+bk api --method PUT /organizations/my-org/pipelines/my-app --data '{
+  "description": "Updated description"
+}'
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--method` | `-X` | `GET` | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH` |
+| `--data` | `-d` | — | Request body (JSON string) |
+| `--output` | `-o` | `text` | Output format: `text`, `json` |
+
+### GraphQL API
+
+```bash
+bk api --graphql --data '{
+  "query": "{ viewer { user { name email } } }"
+}'
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--graphql` | | `false` | Send request to the GraphQL endpoint |
+| `--data` | `-d` | — | GraphQL query as JSON string |
+
+> For comprehensive REST and GraphQL API documentation (endpoints, mutations, pagination, webhooks), see the **buildkite-api** skill.
+
+## Users
+
+Invite users to the organization.
+
+```bash
+bk user invite user@example.com
+```
+
+Sends an invitation email to the specified address. The user gains access based on the organization's default role and team assignments.
+
+## Pipeline Initialization
+
+Scaffold a new `pipeline.yaml` in the current directory:
+
+```bash
+bk init
+```
+
+Creates a starter pipeline definition. Edit the generated file to define build steps.
+
+> For pipeline YAML syntax, step types, and configuration patterns, see the **buildkite-pipelines** skill.
+
+## MCP Server Alternatives
+
+When the Buildkite MCP server is available, agents can use MCP tools for direct access without shell execution. The table below maps CLI commands to their MCP equivalents:
+
+| CLI Command | MCP Tool | Notes |
+|-------------|----------|-------|
+| `bk build create` | `create_build` | MCP handles auth automatically |
+| `bk build view` | `get_build` | MCP returns structured data |
+| `bk build list` | `list_builds` | MCP supports the same filters |
+| `bk job log` | `read_logs`, `tail_logs` | MCP supports streaming |
+| `bk pipeline list` | `list_pipelines` | |
+| `bk pipeline create` | `create_pipeline` | |
+| `bk pipeline update` | `update_pipeline` | |
+| `bk artifact download` | `list_artifacts_for_build`, `get_artifact` | |
+| `bk cluster list` | `list_clusters` | |
+| `bk auth status` | `current_user`, `access_token` | |
+| `bk secret create/list/delete` | — | No MCP equivalent; CLI required |
+| `bk package push` | — | No MCP equivalent; CLI required |
+| `bk job retry` | — | No MCP equivalent; CLI required |
+| `bk job cancel` | — | No MCP equivalent; CLI required |
+| `bk build watch` | — | No MCP equivalent; CLI required |
+| `bk api` | — | Use MCP tools for read operations; CLI for custom API calls |
+
+**When to use CLI vs MCP:** Use MCP tools when available — they handle authentication, pagination, and response parsing automatically. Fall back to the CLI when MCP does not cover the operation (secrets, packages, job retry, build watch) or when the agent needs to execute commands in a Bash workflow.
+
+## Common Mistakes
+
+| Mistake | What happens | Fix |
+|---------|-------------|-----|
+| Running `bk` commands before `bk configure` | Every command fails with authentication errors | Run `bk configure` or `bk auth login` first |
+| Omitting `--pipeline` on build commands | Command fails or targets the wrong pipeline | Always pass `--pipeline <slug>` explicitly |
+| Retrying a job ID that was already retried | API returns 422 error — each job ID can only be retried once | Use the new job ID returned by the first retry |
+| Creating secrets with keys starting with `buildkite` or `bk` | Creation fails — reserved prefix | Choose a different key name (exception: `BUILDKITE_API_TOKEN`) |
+| Passing secret values as literal strings in `--value` | Values persist in shell history and process list | Use env var references (`--value "$TOKEN"`) or interactive prompts |
+| Using `bk build cancel` on a completed build | API returns error — only `scheduled`, `running`, or `failing` builds can be canceled | Check build state with `bk build view` first |
+| Expecting `bk artifact download` to work cross-cluster | Artifacts are cluster-scoped by default | Ensure both pipelines are in the same cluster or configure cross-cluster artifact access |
+| Confusing `bk` CLI with `buildkite-agent` | `bk` runs on local machines to interact with the Buildkite API; `buildkite-agent` runs inside CI job steps | Use `bk` from terminal, `buildkite-agent` inside pipeline step commands |
+
+## Further Reading
+
+- [Buildkite CLI overview](https://buildkite.com/docs/platform/cli)
+- [CLI command reference](https://buildkite.com/docs/platform/cli/reference)
+- [CLI installation](https://buildkite.com/docs/platform/cli/installation)
+- [CLI configuration and authentication](https://buildkite.com/docs/platform/cli/configuration)
+- [Managing secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)

--- a/skills/buildkite-test-engine/SKILL.md
+++ b/skills/buildkite-test-engine/SKILL.md
@@ -1,0 +1,713 @@
+---
+name: buildkite-test-engine
+description: >
+  This skill should be used when the user asks to "split tests across machines",
+  "set up test splitting", "parallelize test suite", "detect flaky tests",
+  "quarantine flaky tests", "configure test collectors", "speed up tests",
+  "set up bktec", "configure test engine", or "reduce flaky test failures".
+  Also use when the user mentions bktec, Test Engine, test suites,
+  BUILDKITE_TEST_ENGINE_* environment variables, BUILDKITE_ANALYTICS_TOKEN,
+  test-collector plugin, test reliability scores, test timing data,
+  or asks about Buildkite test splitting and flaky test management.
+---
+
+# Buildkite Test Engine
+
+Test Engine is Buildkite's testing product for splitting test suites across parallel machines and identifying flaky tests. It operates through two components: **test collectors** that gather timing and reliability data from test runs, and **bktec** (the Test Engine Client CLI) that uses that data for intelligent test splitting and automatic flaky test management.
+
+## Quick Start
+
+Three steps: create a suite, add a collector, run bktec with parallelism.
+
+**1. Create a test suite** in the Buildkite dashboard: Test Suites > New test suite > Set up suite. Copy the suite API token.
+
+**2. Add the test-collector plugin** to start gathering timing data:
+
+```yaml
+steps:
+  - label: ":rspec: Tests"
+    command: "bundle exec rspec"
+    plugins:
+      - test-collector#v2.0.0:
+          files: "tmp/rspec-*.xml"
+          format: "junit"
+    env:
+      BUILDKITE_ANALYTICS_TOKEN: "your-suite-api-token"
+```
+
+**3. After ~1-2 weeks of data**, switch to bktec for intelligent splitting:
+
+```yaml
+steps:
+  - label: ":rspec: Tests %n"
+    command: bktec
+    parallelism: 10
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "my-suite"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "rspec"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/rspec-result.json"
+```
+
+This splits the test suite across 10 parallel agents, balanced by historical runtime, and automatically excludes quarantined flaky tests.
+
+> For `parallelism:` YAML syntax and pipeline structure, see the **buildkite-pipelines** skill.
+
+## How Test Engine Works
+
+Test Engine is a two-phase system:
+
+**Phase 1 — Data collection:** Test collectors (language-specific gems, npm packages, or JUnit XML uploads) send execution timing, pass/fail results, and error details to the Test Engine API after every test run. This builds a historical profile for each test in the suite.
+
+**Phase 2 — Smart splitting + flaky management:** bktec reads the historical data to (a) partition tests across parallel agents so each agent finishes in roughly the same time, and (b) identify and quarantine flaky tests so they stop failing builds.
+
+The data dependency is critical: bktec needs ~1-2 weeks of collector data before timing-based splitting is effective. Without data, bktec falls back to splitting by file count, which produces uneven partitions when test files vary in runtime.
+
+### The Two Token Types
+
+This is the most common source of confusion. Test Engine uses two different tokens for different purposes:
+
+| Token | Environment Variable | Purpose | Where to get it |
+|-------|---------------------|---------|-----------------|
+| **Suite API token** | `BUILDKITE_ANALYTICS_TOKEN` | Collectors use this to send test data to a specific suite | Test suite settings page |
+| **API access token** | `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` | bktec uses this to fetch timing data and test plans | Personal Settings > API Access Tokens (requires `read_suites` scope) |
+
+These are not interchangeable. The suite API token routes data to a suite. The API access token authenticates bktec to read from the Test Engine API.
+
+## Creating Test Suites
+
+### Via the Buildkite dashboard
+
+1. Select **Test Suites** in the global navigation
+2. Select **New test suite**
+3. Select **Set up suite**
+4. If the teams feature is enabled, select relevant teams and continue
+
+The suite settings page shows the **suite API token** (for collectors) and the **suite slug** (for bktec).
+
+### Via the REST API
+
+```bash
+curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  -X POST "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Backend RSpec",
+    "default_branch": "main",
+    "show_api_token": true
+  }'
+```
+
+Set `show_api_token: true` to include the suite API token in the response. The response also contains the `slug` field needed for `BUILDKITE_TEST_ENGINE_SUITE_SLUG`.
+
+> For full REST API details, see the **buildkite-api** skill.
+
+### Suites and pipelines
+
+Pipelines and test suites do not need a one-to-one relationship. Multiple pipelines can report to the same suite (useful for monorepos with a shared test suite), and one pipeline can report to multiple suites (useful for separate unit and integration suites).
+
+## Test Collectors
+
+Collectors send test execution data to Test Engine. Install the collector for the test framework, set `BUILDKITE_ANALYTICS_TOKEN`, and run tests normally. Every framework needs a collector configured before bktec splitting works.
+
+### Ruby — RSpec
+
+Add the gem to the Gemfile:
+
+```ruby
+group :test do
+  gem "buildkite-test_collector"
+end
+```
+
+Configure in `spec_helper.rb` (require gems that patch `Net::HTTP` before this):
+
+```ruby
+require "buildkite/test_collector"
+
+Buildkite::TestCollector.configure(hook: :rspec)
+```
+
+Pipeline step:
+
+```yaml
+steps:
+  - label: ":rspec: Tests"
+    command: "bundle exec rspec"
+    env:
+      BUILDKITE_ANALYTICS_TOKEN: "your-suite-api-token"
+```
+
+### Ruby — Minitest
+
+Same gem, different hook. Configure in `test_helper.rb`:
+
+```ruby
+require "buildkite/test_collector"
+
+Buildkite::TestCollector.configure(hook: :minitest)
+```
+
+### JavaScript — Jest
+
+Install the npm package:
+
+```bash
+npm install --save-dev buildkite-test-collector
+```
+
+Add the reporter to `jest.config.js`:
+
+```javascript
+module.exports = {
+  reporters: [
+    "default",
+    "buildkite-test-collector/jest/reporter"
+  ],
+  testLocationInResults: true
+};
+```
+
+Pipeline step:
+
+```yaml
+steps:
+  - label: ":jest: Tests"
+    command: "npm test"
+    env:
+      BUILDKITE_ANALYTICS_TOKEN: "your-suite-api-token"
+```
+
+### JavaScript — Playwright
+
+Add the reporter to `playwright.config.js`:
+
+```javascript
+module.exports = {
+  reporter: [
+    ["list"],
+    ["buildkite-test-collector/playwright/reporter"]
+  ]
+};
+```
+
+### JavaScript — Cypress
+
+Configure in `cypress.config.js`:
+
+```javascript
+module.exports = {
+  reporter: "buildkite-test-collector/cypress/reporter",
+  reporterOptions: {}
+};
+```
+
+### Python — pytest
+
+bktec supports pytest directly as a test runner. No separate collector package is needed — bktec handles both splitting and result collection when `BUILDKITE_TEST_ENGINE_TEST_RUNNER` is set to `pytest`.
+
+For collecting analytics data without bktec, use the JUnit XML upload method described below.
+
+### Go
+
+Generate JUnit XML with `gotestsum`, then upload to the analytics API:
+
+```yaml
+steps:
+  - label: ":golang: Tests"
+    command: |
+      gotestsum --junitfile junit.xml -- ./...
+      curl \
+        -X POST \
+        --fail-with-body \
+        -H "Authorization: Token token=\"$$BUILDKITE_ANALYTICS_TOKEN\"" \
+        -F "data=@junit.xml" \
+        -F "format=junit" \
+        -F "run_env[CI]=buildkite" \
+        -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+        -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+        -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+        -F "run_env[branch]=$BUILDKITE_BRANCH" \
+        -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+        -F "run_env[message]=$BUILDKITE_MESSAGE" \
+        -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+        https://analytics-api.buildkite.com/v1/uploads
+    env:
+      BUILDKITE_ANALYTICS_TOKEN: "your-suite-api-token"
+```
+
+### JUnit XML Upload — Universal Fallback
+
+Any language that produces JUnit XML can upload results to Test Engine via the analytics API. This is the fallback for languages without a dedicated collector.
+
+```bash
+curl \
+  -X POST \
+  --fail-with-body \
+  -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+  -F "data=@test-results.xml" \
+  -F "format=junit" \
+  -F "run_env[CI]=buildkite" \
+  -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+  -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+  -F "run_env[branch]=$BUILDKITE_BRANCH" \
+  -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+  https://analytics-api.buildkite.com/v1/uploads
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `data` | Yes | The JUnit XML file (`@path/to/file.xml`) |
+| `format` | Yes | Always `junit` for XML uploads |
+| `run_env[CI]` | No | CI platform identifier (e.g., `buildkite`, `github_actions`) |
+| `run_env[key]` | Yes | Unique identifier for this build run |
+| `run_env[number]` | No | Build number |
+| `run_env[branch]` | No | Git branch |
+| `run_env[commit_sha]` | No | Git commit SHA |
+| `run_env[job_id]` | No | Job ID (for parallel builds) |
+| `run_env[message]` | No | Commit message |
+| `run_env[url]` | No | URL to the build |
+
+Maximum 5000 test results per upload. For larger suites, split into multiple uploads using the same `run_env[key]` value.
+
+### test-collector Plugin
+
+As an alternative to framework-specific collectors, the `test-collector` plugin uploads test result files directly:
+
+```yaml
+steps:
+  - label: ":test_tube: Tests"
+    command: "make test"
+    plugins:
+      - test-collector#v2.0.0:
+          files: "tmp/junit-*.xml"
+          format: "junit"
+    env:
+      BUILDKITE_ANALYTICS_TOKEN: "your-suite-api-token"
+```
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `files` | Yes | Glob pattern for test result files |
+| `format` | Yes | Result format: `junit`, `json` |
+
+The plugin runs after the test command, collects matching files, and uploads them to Test Engine. Pin the plugin version (`test-collector#v2.0.0`, not `test-collector#v2`).
+
+### Running collectors locally
+
+Test locally to verify collector configuration before committing:
+
+```bash
+BUILDKITE_ANALYTICS_TOKEN=your-suite-api-token \
+BUILDKITE_ANALYTICS_MESSAGE="Local test run" \
+bundle exec rspec
+```
+
+Results appear in the Test Engine dashboard within seconds.
+
+## bktec CLI
+
+bktec (Buildkite Test Engine Client) is the CLI tool that fetches test plans from Test Engine and runs tests with intelligent splitting. It replaces the test runner command in pipeline steps.
+
+### How bktec works
+
+1. bktec reads `BUILDKITE_PARALLEL_JOB` and `BUILDKITE_PARALLEL_JOB_COUNT` to determine which partition this agent handles
+2. It fetches the test plan from the Test Engine API using timing data from previous runs
+3. It assigns a subset of test files (or examples) to this agent, balanced by historical runtime
+4. It runs the test subset using the configured test runner
+5. It uploads results back to Test Engine
+6. If `BUILDKITE_TEST_ENGINE_RETRY_COUNT` is set, it automatically retries failed tests
+
+### Installation
+
+**Hosted agents (Debian/Ubuntu):**
+
+bktec is pre-installed on Buildkite hosted agents. If not available, install via:
+
+```bash
+curl -sL https://github.com/buildkite/test-engine-client/releases/latest/download/bktec-linux-amd64 -o /usr/local/bin/bktec
+chmod +x /usr/local/bin/bktec
+```
+
+**macOS:**
+
+```bash
+curl -sL https://github.com/buildkite/test-engine-client/releases/latest/download/bktec-darwin-amd64 -o /usr/local/bin/bktec
+chmod +x /usr/local/bin/bktec
+```
+
+### Supported test runners
+
+| Runner | `BUILDKITE_TEST_ENGINE_TEST_RUNNER` value | Notes |
+|--------|------------------------------------------|-------|
+| RSpec | `rspec` | Full support including split-by-example |
+| Jest | `jest` | Splits by test file |
+| Playwright | `playwright` | Splits by test file |
+| Cypress | `cypress` | Splits by spec file |
+| pytest | `pytest` | Splits by test file |
+| pytest-pants | `pytest-pants` | For Pants build system |
+| Go | `go` | Splits by test package |
+| Cucumber | `cucumber` | Splits by feature file |
+
+### Fallback behavior
+
+If bktec cannot reach the Test Engine API or no timing data exists, it falls back to splitting by file count. This produces less even partitions but ensures tests still run. Enable `BUILDKITE_TEST_ENGINE_DEBUG_ENABLED` to see which splitting strategy bktec used.
+
+## bktec Environment Variables
+
+### Required variables
+
+| Variable | Description |
+|----------|-------------|
+| `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` | API access token for authenticating with Test Engine (requires `read_suites` scope) |
+| `BUILDKITE_TEST_ENGINE_SUITE_SLUG` | Slug of the test suite to fetch timing data from |
+| `BUILDKITE_TEST_ENGINE_TEST_RUNNER` | Test runner to use: `rspec`, `jest`, `playwright`, `cypress`, `pytest`, `pytest-pants`, `go`, `cucumber` |
+| `BUILDKITE_TEST_ENGINE_RESULT_PATH` | Path where bktec writes test results (e.g., `tmp/rspec-result.json`) |
+
+### Optional variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BUILDKITE_TEST_ENGINE_RETRY_COUNT` | `0` | Number of times to retry failed tests. Set to `2` for flaky detection |
+| `BUILDKITE_TEST_ENGINE_TEST_CMD` | Runner default | Override the test command bktec executes |
+| `BUILDKITE_TEST_ENGINE_RETRY_CMD` | Runner default | Override the retry command for failed tests |
+| `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` | `false` | Split by individual test example instead of by file (RSpec only) |
+| `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` | Runner default | Glob pattern to select test files (e.g., `spec/**/*_spec.rb`) |
+| `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` | — | Glob pattern to exclude test files from splitting |
+| `BUILDKITE_TEST_ENGINE_DEBUG_ENABLED` | `false` | Enable debug logging to see splitting strategy and file assignments |
+
+### Predefined variables (automatic in Buildkite)
+
+These standard Buildkite variables are available automatically and used by bktec internally. When running tests in Docker or other containers, expose these variables explicitly:
+
+| Variable | Description |
+|----------|-------------|
+| `BUILDKITE_BUILD_ID` | Unique build identifier |
+| `BUILDKITE_JOB_ID` | Unique job identifier |
+| `BUILDKITE_PARALLEL_JOB` | Index of this parallel job (0-based) |
+| `BUILDKITE_PARALLEL_JOB_COUNT` | Total number of parallel jobs |
+| `BUILDKITE_BRANCH` | Git branch |
+| `BUILDKITE_COMMIT` | Git commit SHA |
+| `BUILDKITE_MESSAGE` | Commit message |
+| `BUILDKITE_BUILD_URL` | URL to the build page |
+
+## Test Splitting
+
+### Timing-based splitting
+
+When Test Engine has historical timing data, bktec partitions tests so each parallel agent finishes in approximately the same time. Without timing data, a naive file-count split assigns equal numbers of files to each agent — but if one file takes 60 seconds and another takes 1 second, agents finish at wildly different times.
+
+Timing-based splitting solves this by assigning files to agents based on cumulative runtime. The test plan updates with every build, so splitting improves continuously as more data accumulates.
+
+### Pipeline configuration
+
+Set `parallelism: N` on the step and use `bktec` as the command:
+
+```yaml
+steps:
+  - label: ":rspec: Tests %n"
+    command: bktec
+    parallelism: 10
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "my-suite"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "rspec"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/rspec-result.json"
+```
+
+The `%n` in the label expands to the parallel job index (e.g., "Tests 0", "Tests 1", ..., "Tests 9").
+
+### Complete examples by framework
+
+**RSpec with retry and split-by-example:**
+
+```yaml
+steps:
+  - label: ":rspec: Tests %n"
+    command: bktec
+    parallelism: 10
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "backend-rspec"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "rspec"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/rspec-result.json"
+      BUILDKITE_TEST_ENGINE_RETRY_COUNT: "2"
+      BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE: "true"
+```
+
+**Jest:**
+
+```yaml
+steps:
+  - label: ":jest: Tests %n"
+    command: bktec
+    parallelism: 8
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "frontend-jest"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "jest"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/jest-result.json"
+```
+
+**pytest:**
+
+```yaml
+steps:
+  - label: ":python: Tests %n"
+    command: bktec
+    parallelism: 6
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "backend-pytest"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "pytest"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/pytest-result.json"
+      BUILDKITE_TEST_ENGINE_RETRY_COUNT: "2"
+```
+
+**Go:**
+
+```yaml
+steps:
+  - label: ":golang: Tests %n"
+    command: bktec
+    parallelism: 4
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "backend-go"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "go"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/go-result.json"
+```
+
+### Split by example vs split by file
+
+By default, bktec splits by **file** — each parallel agent gets a set of test files. Set `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` to `true` to split by **individual test example** instead.
+
+Split-by-example produces more even partitions when test files have widely varying numbers of tests (e.g., one file with 200 tests and another with 5). Currently only supported for RSpec.
+
+### Choosing parallelism level
+
+| Suite size | Suggested `parallelism` | Reasoning |
+|------------|------------------------|-----------|
+| < 100 tests | 2-4 | Overhead of splitting outweighs benefit at small scale |
+| 100-500 tests | 4-8 | Good balance of speed improvement vs agent cost |
+| 500-2000 tests | 8-16 | Significant time reduction |
+| 2000+ tests | 16-32 | Large suites benefit most; diminishing returns above 32 |
+
+The optimal value depends on test runtime distribution. Check Test Engine analytics to see if agents finish at roughly the same time — if one agent consistently takes much longer, increase parallelism or enable split-by-example.
+
+### Custom test commands
+
+Override the default test command when the test runner needs additional flags or setup:
+
+```yaml
+env:
+  BUILDKITE_TEST_ENGINE_TEST_CMD: "bundle exec rspec --format documentation"
+  BUILDKITE_TEST_ENGINE_RETRY_CMD: "bundle exec rspec --format documentation --only-failures"
+```
+
+bktec appends the assigned test files to the command automatically.
+
+## Flaky Test Detection
+
+A flaky test produces different results (pass/fail) on the same commit. Flaky tests erode trust in CI — developers stop investigating failures because "it's probably just a flake."
+
+### How Test Engine detects flakes
+
+Test Engine tracks every execution of every test. When the same test on the same commit produces both pass and fail results (across different builds or retries), Test Engine flags it as flaky.
+
+### Automatic retry for flaky detection
+
+Set `BUILDKITE_TEST_ENGINE_RETRY_COUNT` to automatically retry failed tests within the same job. If a test fails on first run but passes on retry, Test Engine records it as flaky:
+
+```yaml
+env:
+  BUILDKITE_TEST_ENGINE_RETRY_COUNT: "2"
+```
+
+This retries each failed test up to 2 times. The build passes if all tests eventually pass (including on retry). Recommended value is `2` — higher values waste compute without meaningfully improving detection.
+
+### Listing flaky tests via the REST API
+
+```bash
+curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  -X GET "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug}/flaky-tests"
+```
+
+The response is a paginated list of tests flagged as flaky, with metadata including failure rate, last seen date, and affected branches.
+
+> For full API pagination and authentication details, see the **buildkite-api** skill.
+
+### Investigating flaky tests with MCP tools
+
+When the Buildkite MCP server is available, use these tools to investigate test failures:
+
+| MCP Tool | Use for |
+|----------|---------|
+| `list_test_runs` | List all runs for a test suite to see recent pass/fail trends |
+| `get_test_run` | Get details of a specific test run including pass/fail/skip counts |
+| `get_test` | Retrieve metadata for a specific test (name, suite, location) |
+| `get_failed_executions` | Get failed executions with error messages and stack traces |
+| `get_build_test_engine_runs` | Get Test Engine runs associated with a specific Pipelines build |
+
+### Flaky test triage workflow
+
+1. Use `list_test_runs` or the Test Engine dashboard to identify suites with high failure rates
+2. Use `get_failed_executions` with expanded failure details to see error messages and stack traces
+3. Determine if failures are environmental (timeouts, network), test-order-dependent, or timing-related
+4. Quarantine confirmed flakes (see Test States and Quarantine below)
+5. Fix the root cause, then remove from quarantine
+
+Target: < 3% flaky test rate. Above this threshold, developers stop trusting CI results.
+
+## Test States and Quarantine
+
+Test Engine assigns a **state** to each test based on its execution history. bktec uses test states to automatically manage flaky tests during test runs.
+
+### Test states
+
+| State | Meaning | bktec behavior |
+|-------|---------|----------------|
+| **Active** | Test runs normally | Included in test runs |
+| **Muted** | Test runs but failures are suppressed | Included in test runs; failures do not fail the build |
+| **Quarantined** | Test is excluded from runs | Excluded from test runs entirely |
+
+### How quarantine works
+
+When a test is quarantined:
+- bktec automatically excludes it from test runs
+- The build is not affected by the quarantined test's pass/fail status
+- Test Engine continues tracking the test's execution in other contexts
+- Quarantine is supported for RSpec, Jest, and Playwright runners
+
+Quarantining prevents flaky tests from causing build failures while the root cause is investigated. This is more targeted than retrying — a quarantined test is skipped entirely, saving both compute time and developer attention.
+
+### Managing test states
+
+Change test states through the Test Engine dashboard:
+1. Navigate to the test suite
+2. Find the test (use search or filter by state)
+3. Select the test and change its state to Active, Muted, or Quarantined
+
+### Pipeline example with quarantine
+
+No special pipeline configuration is needed. bktec reads test states from the Test Engine API automatically:
+
+```yaml
+steps:
+  - label: ":rspec: Tests %n (quarantined tests excluded)"
+    command: bktec
+    parallelism: 10
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "my-suite"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "rspec"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/rspec-result.json"
+```
+
+### Quarantine workflow
+
+1. Identify flaky tests via Test Engine dashboard or `get_failed_executions` MCP tool
+2. Quarantine confirmed flakes through the dashboard
+3. Create tickets to fix the underlying issue
+4. After fixing, change the test state back to Active
+5. Monitor for regressions over the next few builds
+
+## Docker and Containerized Environments
+
+When running tests inside Docker or other containers, expose the Buildkite environment variables that bktec needs. These are available automatically on the host but not inside containers:
+
+```yaml
+steps:
+  - label: ":docker: Tests %n"
+    command: bktec
+    parallelism: 10
+    plugins:
+      - docker#v5.12.0:
+          image: "myapp:test"
+          environment:
+            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
+            - BUILDKITE_TEST_ENGINE_SUITE_SLUG
+            - BUILDKITE_TEST_ENGINE_TEST_RUNNER
+            - BUILDKITE_TEST_ENGINE_RESULT_PATH
+            - BUILDKITE_BUILD_ID
+            - BUILDKITE_JOB_ID
+            - BUILDKITE_PARALLEL_JOB
+            - BUILDKITE_PARALLEL_JOB_COUNT
+            - BUILDKITE_BRANCH
+            - BUILDKITE_COMMIT
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "my-suite"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "rspec"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/rspec-result.json"
+```
+
+The `environment` list in the Docker plugin passes these variables from the host into the container. Without this, bktec cannot determine the parallel job index or authenticate with Test Engine.
+
+## End-to-End Setup Walkthrough
+
+Complete setup from zero to intelligent test splitting:
+
+### Week 1: Collect data
+
+```yaml
+steps:
+  - label: ":rspec: Tests"
+    command: "bundle exec rspec --format progress --format RspecJunitFormatter --out tmp/rspec.xml"
+    plugins:
+      - test-collector#v2.0.0:
+          files: "tmp/rspec.xml"
+          format: "junit"
+    env:
+      BUILDKITE_ANALYTICS_TOKEN: "your-suite-api-token"
+```
+
+Run this for ~1-2 weeks across normal development. Test Engine accumulates timing data for every test in the suite.
+
+### Week 2+: Enable splitting
+
+```yaml
+steps:
+  - label: ":rspec: Tests %n"
+    command: bktec
+    parallelism: 10
+    env:
+      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: "your-api-access-token"
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: "my-suite"
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: "rspec"
+      BUILDKITE_TEST_ENGINE_RESULT_PATH: "tmp/rspec-result.json"
+      BUILDKITE_TEST_ENGINE_RETRY_COUNT: "2"
+```
+
+### Week 3+: Quarantine flakes
+
+Review the Test Engine dashboard for tests flagged as flaky. Quarantine confirmed flakes. Target < 3% flaky rate.
+
+### Ongoing: Monitor and tune
+
+- Check that parallel agents finish within ~10% of each other. If not, adjust `parallelism` or enable split-by-example.
+- Review quarantined tests weekly. Fix root causes and move tests back to Active.
+- Monitor suite trends in the Test Engine dashboard for regressions in test count, runtime, or flaky rate.
+
+## Common Mistakes
+
+| Mistake | What happens | Fix |
+|---------|-------------|-----|
+| Using `BUILDKITE_ANALYTICS_TOKEN` where `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` is needed (or vice versa) | Collector uploads fail, or bktec cannot fetch test plans | Analytics token is for collectors (suite-scoped). API access token is for bktec (user-scoped with `read_suites`). |
+| Running bktec before collectors have gathered enough data | bktec falls back to file-count splitting, producing uneven partitions | Run collectors for 1-2 weeks before switching to bktec. Enable `BUILDKITE_TEST_ENGINE_DEBUG_ENABLED` to verify timing-based splitting is active. |
+| Not exposing Buildkite env vars in Docker containers | bktec cannot determine parallel job index, defaults to running all tests on every agent | Pass `BUILDKITE_PARALLEL_JOB`, `BUILDKITE_PARALLEL_JOB_COUNT`, and other required vars via the Docker plugin `environment` list. |
+| Setting `parallelism` higher than the number of test files | Some agents receive zero tests and exit immediately, wasting compute | Set `parallelism` to at most the number of test files. Check Test Engine analytics for optimal value. |
+| Omitting `BUILDKITE_TEST_ENGINE_RESULT_PATH` | bktec cannot write test results, preventing data from feeding back into Test Engine | Always set the result path (e.g., `tmp/rspec-result.json`). |
+| Using an incorrect `BUILDKITE_TEST_ENGINE_TEST_RUNNER` value | bktec fails to start or uses wrong test execution strategy | Use exact values: `rspec`, `jest`, `playwright`, `cypress`, `pytest`, `pytest-pants`, `go`, `cucumber`. |
+| Not pinning `test-collector` plugin version | Plugin updates may change behavior or introduce breaking changes | Always pin: `test-collector#v2.0.0`, not `test-collector#v2`. |
+| Setting `BUILDKITE_TEST_ENGINE_RETRY_COUNT` above 3 | Excessive retries waste compute and mask genuine failures | Use `2` for flaky detection. Higher values rarely help and significantly increase build time for truly broken tests. |
+
+## Further Reading
+
+- [Test Engine overview](https://buildkite.com/docs/test-engine)
+- [Speed up builds with bktec](https://buildkite.com/docs/test-engine/speed-up-builds-with-bktec)
+- [Configuring bktec](https://buildkite.com/docs/test-engine/bktec/configuring)
+- [Test collection](https://buildkite.com/docs/test-engine/test-collection)
+- [Test states and quarantine](https://buildkite.com/docs/test-engine/test-suites/test-state-and-quarantine)
+- [Flaky tests REST API](https://buildkite.com/docs/apis/rest-api/test-engine/flaky-tests)
+- [bktec source (GitHub)](https://github.com/buildkite/test-engine-client)

--- a/skills/buildkite-test-engine/agents/openai.yaml
+++ b/skills/buildkite-test-engine/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Buildkite Test Engine"
+  short_description: "Test splitting, flaky detection, quarantine, and bktec CLI"
+  icon_small: "./assets/buildkite-icon-small.png"
+  icon_large: "./assets/buildkite-icon-large.png"
+  brand_color: "#00D974"


### PR DESCRIPTION
## Summary

- **buildkite-agent-runtime**: New cross-cutting skill covering all `buildkite-agent` subcommands used inside job steps (annotate, artifact, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor, tool sign/verify). Includes exhaustive flag reference tables and 10 multi-subcommand recipe patterns.
- **buildkite-cli**: Fully written skill (was a stub) for the `bk` CLI — builds, jobs, pipelines, secrets, artifacts, clusters, packages, with flag tables and MCP server alternatives noted.
- **buildkite-test-engine**: New skill for `bktec` CLI, test splitting, flaky detection, quarantine, collectors, and suite configuration.
- **v2 proposal updated**: Adds agent-runtime as the 7th skill, refines skill boundaries, adds the pipelines-vs-agent-runtime ambiguity rule.

## File breakdown

| File | Size | Content |
|------|------|---------|
| `skills/buildkite-agent-runtime/SKILL.md` | 26KB | 11 subcommand sections, 10 common mistakes, 8 further reading links |
| `skills/buildkite-agent-runtime/references/flag-reference.md` | 15KB | Exhaustive flag tables for every subcommand |
| `skills/buildkite-agent-runtime/references/patterns-and-recipes.md` | 14KB | 10 real-world multi-subcommand recipes |
| `skills/buildkite-cli/SKILL.md` | ~22KB | Full CLI skill (was a TODO stub) |
| `skills/buildkite-test-engine/SKILL.md` | ~29KB | Full test engine skill |
| `buildkite-skills-proposal-v2.md` | +90 lines | Updated proposal with agent-runtime boundaries |

## Test plan

- [ ] Verify YAML frontmatter parses correctly in all SKILL.md files
- [ ] Confirm no boundary violations (each skill stays in its lane)
- [ ] Cross-references between skills use correct skill names
- [ ] Code examples are syntactically valid bash/yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)