### PR TITLE
Add trigger precision evals

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -142,7 +142,72 @@ This shows which evals flipped (FIXED/REGRESSED) and the pass rate delta.
 
 The script exits with code 1 if any eval fails, making it usable in CI.
 
-## Adding Evals
+### Trigger Precision Eval Runner
+
+`run_trigger.py` tests whether Claude selects the correct skill based on description alone. It presents all skill descriptions in a system prompt, sends a query, and checks whether the model picks the right skill. This tests **routing accuracy** — complementary to the quality runner which tests **answer correctness**.
+
+Uses a separate dataset (`trigger_dataset.yaml`) with should-trigger and near-miss entries per skill.
+
+```bash
+# Run all trigger evals
+python evals/run_trigger.py
+
+# Filter to evals targeting a specific skill
+python evals/run_trigger.py --skill buildkite-pipelines
+
+# Only run near-miss entries
+python evals/run_trigger.py --tag near-miss
+
+# Multi-run for trigger rate reliability (3 runs per query)
+python evals/run_trigger.py --runs 3
+
+# Only holdout split (40%) for validation after description tuning
+python evals/run_trigger.py --holdout
+
+# Parallel execution (default: 5 concurrent)
+python evals/run_trigger.py --parallel 10
+
+# Compare against previous run
+python evals/run_trigger.py --compare evals/results/trigger-20260326-120000.json
+```
+
+#### Trigger Dataset Format
+
+Each eval in `trigger_dataset.yaml`:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique identifier (`t-{skill}-NNN` or `t-{skill}-nNN` for near-misses) |
+| `query` | User question to route |
+| `expected_skill` | Which skill should be selected |
+| `expected_not_skills` | Skills that must NOT be selected (for near-miss testing) |
+| `tags` | `should-trigger`, `near-miss`, boundary labels like `pipelines-vs-runtime` |
+
+#### Trigger Metrics
+
+- **Accuracy**: overall correct routing rate
+- **Per-skill precision**: of queries where skill X was selected, what fraction should have been?
+- **Per-skill recall**: of queries where skill X should have been selected, what fraction was?
+- **F1**: harmonic mean of precision and recall
+- **Confusion matrix**: expected (rows) vs selected (columns) — reveals systematic misrouting
+
+#### Quality vs Trigger: When to Use Which
+
+| | Quality (`run_quality.py`) | Trigger (`run_trigger.py`) |
+|---|---|---|
+| **Tests** | Does the skill content produce correct answers? | Does Claude pick the right skill? |
+| **When to run** | After editing SKILL.md content | After editing skill description (frontmatter) |
+| **Fix loop** | Improve skill body content | Improve description trigger phrases |
+
+#### Adding Trigger Evals
+
+1. Use `t-{skill}-NNN` for should-trigger, `t-{skill}-nNN` for near-misses
+2. Near-misses are the most valuable — use shared keywords but different intent
+3. Focus on known boundary overlaps (e.g., `pipelines` vs `agent-runtime` for artifacts)
+4. Include `expected_not_skills` for near-miss entries
+5. Tag with the boundary being tested (e.g., `pipelines-vs-runtime`)
+
+## Adding Quality Evals
 
 1. Use the next available ID in the relevant cluster (e.g., `pipeline-009`)
 2. Prefer real questions from Plain/Avoma over synthetic ones

--- a/evals/lib/dataset.py
+++ b/evals/lib/dataset.py
@@ -7,6 +7,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DATASET_PATH = REPO_ROOT / "evals" / "dataset.yaml"
+TRIGGER_DATASET_PATH = REPO_ROOT / "evals" / "trigger_dataset.yaml"
 SKILLS_DIR = REPO_ROOT / "skills"
 
 
@@ -88,3 +89,61 @@ def load_skill(skill_name: str) -> tuple[str, str]:
 def skill_path(skill_name: str) -> Path:
     """Return the path to a skill's SKILL.md."""
     return SKILLS_DIR / skill_name / "SKILL.md"
+
+
+# --- Trigger eval functions ---
+
+
+def load_trigger_dataset(path: Path = TRIGGER_DATASET_PATH) -> list[dict]:
+    """Load trigger evals from trigger_dataset.yaml."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return data.get("trigger_evals", [])
+
+
+def load_all_skill_descriptions() -> dict[str, str]:
+    """Load name->description mapping for all skills with SKILL.md files.
+
+    Returns dict like {"buildkite-pipelines": "This skill should be used when..."}
+    Only includes skills that have a non-empty description in frontmatter.
+    """
+    descriptions = {}
+    for skill_dir in sorted(SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        if skill_md.exists():
+            description, _ = load_skill(skill_dir.name)
+            if description:
+                descriptions[skill_dir.name] = description
+    return descriptions
+
+
+def filter_trigger_evals(
+    evals: list[dict],
+    skill: str | None = None,
+    tags: list[str] | None = None,
+    ids: list[str] | None = None,
+    holdout: bool = False,
+    holdout_ratio: float = 0.4,
+) -> list[dict]:
+    """Filter trigger evals by criteria. All filters are AND-ed together."""
+    result = evals
+
+    if skill:
+        result = [e for e in result if e.get("expected_skill") == skill]
+
+    if tags:
+        result = [
+            e for e in result
+            if any(t in e.get("tags", []) for t in tags)
+        ]
+
+    if ids:
+        id_set = set(ids)
+        result = [e for e in result if e.get("id") in id_set]
+
+    if holdout:
+        result = [e for e in result if _is_holdout(e["id"], holdout_ratio)]
+
+    return result

--- a/evals/lib/graders.py
+++ b/evals/lib/graders.py
@@ -49,3 +49,30 @@ def grade_eval(response: str, eval_entry: dict) -> dict:
         "response_length": len(response),
         "response": response,
     }
+
+
+# --- Trigger eval grading ---
+
+
+def grade_trigger(selected_skill: str | None, eval_entry: dict) -> dict:
+    """Grade a trigger eval result.
+
+    Returns dict with: passed, selected_skill, expected_skill,
+    correct_selection, is_false_positive, is_false_negative, expected_not_violations.
+    """
+    expected = eval_entry.get("expected_skill")
+    expected_not = eval_entry.get("expected_not_skills", [])
+
+    correct = (selected_skill == expected)
+    not_violations = [s for s in expected_not if selected_skill == s]
+    passed = correct and len(not_violations) == 0
+
+    return {
+        "passed": passed,
+        "selected_skill": selected_skill,
+        "expected_skill": expected,
+        "correct_selection": correct,
+        "expected_not_violations": not_violations,
+        "is_false_positive": expected is None and selected_skill is not None,
+        "is_false_negative": expected is not None and selected_skill is None,
+    }

--- a/evals/lib/reporter.py
+++ b/evals/lib/reporter.py
@@ -1,6 +1,7 @@
 """Terminal output and JSON result reporting for eval runs."""
 
 import json
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -180,4 +181,284 @@ def print_comparison(current_results: list[dict], current_evals: list[dict], com
     sign = "+" if delta >= 0 else ""
     color = GREEN if delta > 0 else RED if delta < 0 else DIM
     print(f"\n  Pass rate: {prev_rate:.1f}% → {curr_rate:.1f}% ({_c(color, f'{sign}{delta:.1f}%')})")
+    print()
+
+
+# --- Trigger eval reporting ---
+
+
+def print_trigger_header(
+    model: str,
+    eval_count: int,
+    skill_count: int,
+    filters: str,
+    runs_per_query: int,
+):
+    """Print header for a trigger eval run."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"\n{_c(BOLD, 'Trigger Eval')} — {now}")
+    print(f"Model: {model}")
+    print(f"Skills: {skill_count} descriptions loaded")
+    print(f"Evals: {eval_count}{f' ({filters})' if filters else ''}")
+    if runs_per_query > 1:
+        print(f"Runs per query: {runs_per_query}")
+    print()
+
+
+def print_trigger_result(eval_entry: dict, grade: dict):
+    """Print a single trigger eval result line."""
+    eval_id = eval_entry["id"]
+    query = eval_entry["query"]
+    expected = grade["expected_skill"] or "none"
+    selected = grade["selected_skill"] or "none"
+
+    max_q = 60
+    q_display = query[:max_q] + "..." if len(query) > max_q else query
+
+    if grade["passed"]:
+        status = _c(GREEN, "PASS")
+        detail = f"→ {selected}"
+    else:
+        status = _c(RED, "FAIL")
+        detail = f"expected {_c(BOLD, expected)}, got {_c(RED, selected)}"
+
+    print(f"  {status}  {eval_id:<20s} {detail}")
+    print(f"        {_c(DIM, q_display)}")
+
+
+def print_trigger_multi_result(eval_entry: dict, run_grades: list[dict]):
+    """Print a trigger eval result with multi-run trigger rates."""
+    eval_id = eval_entry["id"]
+    query = eval_entry["query"]
+    expected = eval_entry.get("expected_skill") or "none"
+    total_runs = len(run_grades)
+    correct_runs = sum(1 for g in run_grades if g["passed"])
+
+    max_q = 60
+    q_display = query[:max_q] + "..." if len(query) > max_q else query
+
+    rate = correct_runs / total_runs
+    if rate == 1.0:
+        status = _c(GREEN, "PASS")
+    elif rate >= 0.5:
+        status = _c(YELLOW, "FLAKY")
+    else:
+        status = _c(RED, "FAIL")
+
+    # Show which skills were selected across runs
+    selections = {}
+    for g in run_grades:
+        s = g["selected_skill"] or "none"
+        selections[s] = selections.get(s, 0) + 1
+    sel_display = ", ".join(f"{s}:{n}" for s, n in sorted(selections.items(), key=lambda x: -x[1]))
+
+    detail = f"{correct_runs}/{total_runs} correct  [{sel_display}]"
+    print(f"  {status}  {eval_id:<20s} {detail}")
+    print(f"        {_c(DIM, q_display)}")
+
+
+def print_trigger_summary(grades: list[dict], evals: list[dict], skill_names: list[str]):
+    """Print trigger eval summary with per-skill precision/recall and confusion matrix."""
+    total = len(grades)
+    passed = sum(1 for g in grades if g["passed"])
+    pass_rate = (passed / total * 100) if total else 0
+
+    print(f"\n{_c(BOLD, 'Summary:')}")
+    color = GREEN if pass_rate >= 90 else YELLOW if pass_rate >= 70 else RED
+    print(f"  Accuracy: {_c(color, f'{passed}/{total}')} ({pass_rate:.1f}%)")
+
+    false_pos = sum(1 for g in grades if g["is_false_positive"])
+    false_neg = sum(1 for g in grades if g["is_false_negative"])
+    if false_pos or false_neg:
+        print(f"  False positives: {false_pos}  |  False negatives: {false_neg}")
+
+    # Per-skill precision/recall
+    print(f"\n  {_c(BOLD, 'Per-skill metrics:')}")
+    print(f"  {'Skill':<28s} {'Prec':>6s} {'Recall':>7s} {'F1':>6s}")
+    print(f"  {'─' * 50}")
+
+    for skill in skill_names:
+        tp = sum(1 for g in grades if g["expected_skill"] == skill and g["selected_skill"] == skill)
+        fp = sum(1 for g in grades if g["expected_skill"] != skill and g["selected_skill"] == skill)
+        fn = sum(1 for g in grades if g["expected_skill"] == skill and g["selected_skill"] != skill)
+
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+
+        # Only show skills that appear in results
+        if tp + fp + fn == 0:
+            continue
+
+        p_color = GREEN if precision >= 0.9 else YELLOW if precision >= 0.7 else RED
+        r_color = GREEN if recall >= 0.9 else YELLOW if recall >= 0.7 else RED
+        f_color = GREEN if f1 >= 0.9 else YELLOW if f1 >= 0.7 else RED
+
+        print(
+            f"  {skill:<28s} "
+            f"{_rpad(_c(p_color, f'{precision:.0%}'), 6)} "
+            f"{_rpad(_c(r_color, f'{recall:.0%}'), 7)} "
+            f"{_rpad(_c(f_color, f'{f1:.0%}'), 6)}"
+        )
+
+    # Confusion matrix
+    _print_confusion_matrix(grades, skill_names)
+
+    # List failures
+    failures = [(g, e) for g, e in zip(grades, evals) if not g["passed"]]
+    if failures:
+        print(f"\n  {_c(BOLD, 'Failures:')}")
+        for g, e in failures:
+            expected = g["expected_skill"] or "none"
+            selected = g["selected_skill"] or "none"
+            print(f"    {e['id']}: expected {expected}, got {selected}")
+    print()
+
+
+def _rpad(text: str, width: int) -> str:
+    """Right-align text accounting for ANSI escape codes."""
+    visible_len = len(re.sub(r"\033\[[0-9;]*m", "", text))
+    padding = max(0, width - visible_len)
+    return " " * padding + text
+
+
+def _print_confusion_matrix(grades: list[dict], skill_names: list[str]):
+    """Print an ASCII confusion matrix (expected rows x selected columns)."""
+    # Short labels for display
+    labels = []
+    for s in skill_names:
+        short = s.replace("buildkite-", "")
+        labels.append(short)
+    labels.append("none")
+
+    all_names = skill_names + [None]
+
+    # Build matrix
+    matrix = {}
+    for expected in all_names:
+        matrix[expected] = {}
+        for selected in all_names:
+            matrix[expected][selected] = 0
+
+    for g in grades:
+        exp = g["expected_skill"]
+        sel = g["selected_skill"]
+        if exp in matrix and sel in matrix[exp]:
+            matrix[exp][sel] += 1
+
+    # Check if matrix has any data
+    if not any(matrix[exp][sel] for exp in all_names for sel in all_names):
+        return
+
+    row_width = max(len(l) for l in labels) + 2
+    col_width = max(max(len(l) for l in labels), 4) + 2
+
+    print(f"\n  {_c(BOLD, 'Confusion matrix')} (rows=expected, cols=selected):")
+
+    # Header row
+    header = " " * (row_width + 2)
+    for label in labels:
+        header += _c(DIM, label.rjust(col_width))
+    print(header)
+
+    # Separator
+    print(f"  {'─' * row_width}┬{'─' * (col_width * len(labels))}")
+
+    # Data rows
+    for i, exp in enumerate(all_names):
+        row_label = labels[i].rjust(row_width)
+        row = f"  {row_label}│"
+        for j, sel in enumerate(all_names):
+            count = matrix[exp][sel]
+            if count == 0:
+                cell = _c(DIM, "·")
+            elif i == j:
+                cell = _c(GREEN, str(count))
+            else:
+                cell = _c(RED, str(count))
+            row += _rpad(cell, col_width)
+        print(row)
+
+
+def write_trigger_json_results(
+    grades: list[dict],
+    evals: list[dict],
+    model: str,
+    skill_names: list[str],
+    runs_per_query: int,
+) -> Path:
+    """Write trigger eval results to a JSON file and return the path."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    filename = f"trigger-{timestamp}.json"
+    path = RESULTS_DIR / filename
+
+    total = len(grades)
+    passed = sum(1 for g in grades if g["passed"])
+
+    output = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "eval_type": "trigger",
+        "model": model,
+        "skills": skill_names,
+        "runs_per_query": runs_per_query,
+        "total": total,
+        "passed": passed,
+        "accuracy": round(passed / total, 4) if total else 0,
+        "results": [
+            {
+                "id": e["id"],
+                "query": e["query"],
+                "tags": e.get("tags", []),
+                **g,
+            }
+            for g, e in zip(grades, evals)
+        ],
+    }
+
+    path.write_text(json.dumps(output, indent=2) + "\n")
+    return path
+
+
+def print_trigger_comparison(
+    current_grades: list[dict],
+    current_evals: list[dict],
+    compare_path: str,
+):
+    """Load a previous trigger result file and print what changed."""
+    prev = json.loads(Path(compare_path).read_text())
+    prev_by_id = {r["id"]: r for r in prev["results"]}
+
+    fixed = []
+    regressed = []
+
+    for g, e in zip(current_grades, current_evals):
+        eid = e["id"]
+        if eid not in prev_by_id:
+            continue
+        prev_r = prev_by_id[eid]
+        if not prev_r["passed"] and g["passed"]:
+            fixed.append(eid)
+        elif prev_r["passed"] and not g["passed"]:
+            regressed.append(eid)
+
+    prev_rate = prev.get("accuracy", 0) * 100
+    curr_passed = sum(1 for g in current_grades if g["passed"])
+    curr_rate = (curr_passed / len(current_grades) * 100) if current_grades else 0
+    delta = curr_rate - prev_rate
+
+    print(f"\n{_c(BOLD, 'Comparison')} vs {Path(compare_path).name}:")
+
+    if fixed:
+        for eid in fixed:
+            print(f"  {_c(GREEN, 'FIXED')}      {eid}")
+    if regressed:
+        for eid in regressed:
+            print(f"  {_c(RED, 'REGRESSED')}  {eid}")
+
+    if not fixed and not regressed:
+        print(f"  No changes in pass/fail status")
+
+    sign = "+" if delta >= 0 else ""
+    color = GREEN if delta > 0 else RED if delta < 0 else DIM
+    print(f"\n  Accuracy: {prev_rate:.1f}% → {curr_rate:.1f}% ({_c(color, f'{sign}{delta:.1f}%')})")
     print()

--- a/evals/run_trigger.py
+++ b/evals/run_trigger.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Trigger precision eval runner for Buildkite skills.
+
+Tests whether Claude selects the correct skill given all skill descriptions
+and a user query. Presents all descriptions in a system prompt and asks the
+model to return a JSON skill selection.
+
+Usage:
+    python evals/run_trigger.py
+    python evals/run_trigger.py --skill buildkite-pipelines
+    python evals/run_trigger.py --tag near-miss
+    python evals/run_trigger.py --runs 3 --parallel 5
+    python evals/run_trigger.py --holdout
+    python evals/run_trigger.py --compare evals/results/trigger-prev.json
+
+Requires: ANTHROPIC_API_KEY environment variable.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import anthropic
+
+from lib.dataset import (
+    load_trigger_dataset,
+    load_all_skill_descriptions,
+    filter_trigger_evals,
+)
+from lib.graders import grade_trigger
+from lib.reporter import (
+    print_trigger_header,
+    print_trigger_result,
+    print_trigger_multi_result,
+    print_trigger_summary,
+    write_trigger_json_results,
+    print_trigger_comparison,
+)
+
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+
+
+def build_system_prompt(skill_descriptions: dict[str, str]) -> str:
+    """Build the system prompt presenting all skill descriptions."""
+    skills_block = "\n\n".join(
+        f"### {name}\n{desc}" for name, desc in sorted(skill_descriptions.items())
+    )
+
+    return (
+        "You are a skill router for Buildkite CI/CD. Given a user query, "
+        "select the single most appropriate skill to handle it, or select "
+        "null if no skill is relevant.\n\n"
+        "Available skills:\n\n"
+        f"{skills_block}\n\n"
+        'Respond with ONLY a JSON object: {"skill": "<skill-name>"} or {"skill": null}\n'
+        "Do not explain your reasoning."
+    )
+
+
+def parse_skill_selection(response: str, valid_skills: list[str]) -> str | None:
+    """Extract skill name from model's JSON response.
+
+    Tries JSON parsing first, then regex, then scans for known skill names.
+    Returns None if no skill selected or unparseable.
+    """
+    text = response.strip()
+
+    # Try JSON parse
+    try:
+        data = json.loads(text)
+        skill = data.get("skill")
+        if skill is None or skill == "null":
+            return None
+        if skill in valid_skills:
+            return skill
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    # Try regex for {"skill": "..."} pattern
+    match = re.search(r'"skill"\s*:\s*"([^"]+)"', text)
+    if match:
+        skill = match.group(1)
+        if skill in valid_skills:
+            return skill
+
+    # Try regex for null
+    match = re.search(r'"skill"\s*:\s*null', text)
+    if match:
+        return None
+
+    # Scan for known skill names in the text
+    for skill in valid_skills:
+        if skill in text:
+            return skill
+
+    print(f"  WARNING: Could not parse skill from response: {text[:100]}", file=sys.stderr)
+    return None
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run trigger precision evals for Buildkite skills")
+    p.add_argument("--skill", help="Filter to evals targeting a specific skill (by expected_skill)")
+    p.add_argument("--tag", action="append", help="Filter by tag (can repeat)")
+    p.add_argument("--id", help="Comma-separated eval IDs to run")
+    p.add_argument("--model", default=DEFAULT_MODEL, help=f"Model to use (default: {DEFAULT_MODEL})")
+    p.add_argument("--runs", type=int, default=1, help="Runs per query for trigger rate (default: 1, max 5)")
+    p.add_argument("--parallel", type=int, default=5, metavar="N", help="Run N evals concurrently (default: 5)")
+    p.add_argument("--holdout", action="store_true", help="Only run holdout split (40%%)")
+    p.add_argument("--compare", metavar="FILE", help="Compare against a previous trigger results JSON file")
+    p.add_argument("--no-save", action="store_true", help="Don't save results to JSON")
+    p.add_argument("--show-responses", action="store_true", help="Print raw model responses")
+    return p.parse_args()
+
+
+async def run_single_trigger(
+    client: anthropic.AsyncAnthropic,
+    model: str,
+    system_prompt: str,
+    query: str,
+) -> str:
+    """Send a single query and return the raw response text."""
+    response = await client.messages.create(
+        model=model,
+        max_tokens=100,
+        system=system_prompt,
+        messages=[{"role": "user", "content": query}],
+    )
+    return response.content[0].text
+
+
+async def run_trigger_eval(
+    client: anthropic.AsyncAnthropic,
+    model: str,
+    system_prompt: str,
+    eval_entry: dict,
+    valid_skills: list[str],
+    runs: int,
+) -> tuple[dict, dict | list[dict], str]:
+    """Run a trigger eval (possibly multiple times).
+
+    Returns (eval_entry, grade_or_grades, last_response_text).
+    When runs=1, grade is a single dict. When runs>1, it's a list.
+    """
+    if runs == 1:
+        text = await run_single_trigger(client, model, system_prompt, eval_entry["query"])
+        selected = parse_skill_selection(text, valid_skills)
+        grade = grade_trigger(selected, eval_entry)
+        return eval_entry, grade, text
+    else:
+        grades = []
+        last_text = ""
+        for _ in range(runs):
+            text = await run_single_trigger(client, model, system_prompt, eval_entry["query"])
+            last_text = text
+            selected = parse_skill_selection(text, valid_skills)
+            grades.append(grade_trigger(selected, eval_entry))
+        return eval_entry, grades, last_text
+
+
+async def run_batch(
+    client: anthropic.AsyncAnthropic,
+    model: str,
+    system_prompt: str,
+    evals: list[dict],
+    valid_skills: list[str],
+    parallel: int,
+    runs: int,
+    show_responses: bool,
+) -> tuple[list[dict], list[dict]]:
+    """Run all trigger evals with concurrency. Returns (grades, evals_in_order).
+
+    For multi-run mode, grades are aggregated (majority vote).
+    """
+    semaphore = asyncio.Semaphore(parallel)
+
+    async def run_with_semaphore(eval_entry):
+        async with semaphore:
+            return await run_trigger_eval(
+                client, model, system_prompt, eval_entry, valid_skills, runs
+            )
+
+    tasks = [run_with_semaphore(e) for e in evals]
+
+    final_grades = []
+    ordered_evals = []
+
+    for coro in asyncio.as_completed(tasks):
+        eval_entry, grade_or_grades, response_text = await coro
+        ordered_evals.append(eval_entry)
+
+        if runs == 1:
+            final_grades.append(grade_or_grades)
+            print_trigger_result(eval_entry, grade_or_grades)
+        else:
+            # Multi-run: use majority vote for the aggregate grade
+            run_grades = grade_or_grades
+            correct_count = sum(1 for g in run_grades if g["passed"])
+            # Use the most common selection as the aggregate
+            selections = {}
+            for g in run_grades:
+                s = g["selected_skill"]
+                selections[s] = selections.get(s, 0) + 1
+            majority_skill = max(selections, key=selections.get)
+            aggregate = grade_trigger(majority_skill, eval_entry)
+            aggregate["trigger_rate"] = correct_count / len(run_grades)
+            aggregate["run_details"] = run_grades
+            final_grades.append(aggregate)
+            print_trigger_multi_result(eval_entry, run_grades)
+
+        if show_responses:
+            print(f"        Response: {response_text}")
+            print()
+
+    return final_grades, ordered_evals
+
+
+def main():
+    args = parse_args()
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("Error: ANTHROPIC_API_KEY environment variable is required.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.runs < 1 or args.runs > 5:
+        print("Error: --runs must be between 1 and 5.", file=sys.stderr)
+        sys.exit(1)
+
+    # Load skill descriptions
+    skill_descriptions = load_all_skill_descriptions()
+    skill_names = sorted(skill_descriptions.keys())
+
+    if not skill_descriptions:
+        print("Error: No skills found with descriptions.", file=sys.stderr)
+        sys.exit(1)
+
+    # Load and filter trigger dataset
+    all_evals = load_trigger_dataset()
+    ids = args.id.split(",") if args.id else None
+    evals = filter_trigger_evals(
+        all_evals,
+        skill=args.skill,
+        tags=args.tag,
+        ids=ids,
+        holdout=args.holdout,
+    )
+
+    if not evals:
+        print(f"No trigger evals found matching filters.", file=sys.stderr)
+        sys.exit(1)
+
+    # Build system prompt
+    system_prompt = build_system_prompt(skill_descriptions)
+
+    # Build filter description
+    filter_parts = []
+    if args.skill:
+        filter_parts.append(f"expected_skill={args.skill}")
+    if args.tag:
+        filter_parts.append(f"tags={','.join(args.tag)}")
+    if args.id:
+        filter_parts.append(f"ids={args.id}")
+    if args.holdout:
+        filter_parts.append("holdout=true")
+
+    print_trigger_header(
+        args.model, len(evals), len(skill_names),
+        ", ".join(filter_parts), args.runs,
+    )
+
+    # Run evals (always async for simplicity since responses are tiny)
+    client = anthropic.AsyncAnthropic()
+    grades, ordered_evals = asyncio.run(
+        run_batch(
+            client, args.model, system_prompt, evals,
+            skill_names, args.parallel, args.runs, args.show_responses,
+        )
+    )
+
+    # Summary
+    print_trigger_summary(grades, ordered_evals, skill_names)
+
+    # Save results
+    if not args.no_save:
+        result_path = write_trigger_json_results(
+            grades, ordered_evals, args.model, skill_names, args.runs,
+        )
+        print(f"Results saved to: {result_path}")
+
+    # Compare
+    if args.compare:
+        print_trigger_comparison(grades, ordered_evals, args.compare)
+
+    # Exit with non-zero if any failures
+    if any(not g["passed"] for g in grades):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/trigger_dataset.yaml
+++ b/evals/trigger_dataset.yaml
@@ -1,0 +1,661 @@
+# Buildkite Skills Trigger Precision Evals
+# Generated: 2026-03-26
+#
+# Purpose: Test whether Claude selects the correct skill given all skill
+# descriptions. Each entry has a query, the expected skill, and optionally
+# skills that must NOT be selected (near-misses).
+#
+# Near-miss entries are the most valuable — they share keywords with the
+# wrong skill but have different intent.
+#
+# Target: ~20 entries per complete skill, ~10 for stubs.
+
+trigger_evals:
+
+  # ============================================================
+  # BUILDKITE-PIPELINES — should trigger
+  # ============================================================
+
+  - id: "t-pipelines-001"
+    query: "How do I write a pipeline.yml with parallel steps?"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-002"
+    query: "I need to add caching to my Buildkite build to speed it up"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-003"
+    query: "What step types are available in a Buildkite pipeline?"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-004"
+    query: "how do i set up a matrix build that tests across multiple ruby versions"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-005"
+    query: "I want to trigger a pipeline only when files in the src/ directory change"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-006"
+    query: "We hit the 500 jobs per pipeline upload limit. Can it be increased?"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-007"
+    query: "How do I add the docker-compose plugin to my pipeline?"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-008"
+    query: "Why did my wait step proceed even though a prior step failed?"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-009"
+    query: "Can I set up notifications in my pipeline YAML to send to Slack on failure?"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  - id: "t-pipelines-010"
+    query: "What's the difference between depends_on and a wait step?"
+    expected_skill: "buildkite-pipelines"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-PIPELINES — near-miss (should NOT trigger pipelines)
+  # ============================================================
+
+  - id: "t-pipelines-n01"
+    query: "How do I install the buildkite-agent on Ubuntu?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-agent"]
+
+  - id: "t-pipelines-n02"
+    query: "I want to upload an artifact from inside my running build step"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-runtime"]
+
+  - id: "t-pipelines-n03"
+    query: "How do I dynamically upload pipeline YAML from a script running in a step?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-runtime"]
+
+  - id: "t-pipelines-n04"
+    query: "How do I use buildkite-agent annotate to add a markdown summary to my build?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-runtime"]
+
+  - id: "t-pipelines-n05"
+    query: "How do I configure agent tags for routing jobs to specific machines?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-agent"]
+
+  - id: "t-pipelines-n06"
+    query: "I want to trigger a build from the command line"
+    expected_skill: "buildkite-cli"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-cli"]
+
+  - id: "t-pipelines-n07"
+    query: "How do I set up a webhook to get notified when builds finish?"
+    expected_skill: "buildkite-platform"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-platform"]
+
+  - id: "t-pipelines-n08"
+    query: "How do I split my test suite across parallel agents using bktec?"
+    expected_skill: "buildkite-test-engine"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-test-engine"]
+
+  - id: "t-pipelines-n09"
+    query: "How do I share a value between two steps using meta-data set and get?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-runtime"]
+
+  - id: "t-pipelines-n10"
+    query: "How do I write a pre-command hook that runs before every job on my agent?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-pipelines"]
+    tags: ["near-miss", "pipelines-vs-agent"]
+
+  # ============================================================
+  # BUILDKITE-CLI — should trigger
+  # ============================================================
+
+  - id: "t-cli-001"
+    query: "How do I trigger a build from the terminal?"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-002"
+    query: "I want to watch a build's progress in my terminal"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-003"
+    query: "How do I download build artifacts using the bk command?"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-004"
+    query: "how do i authenticate the buildkite CLI"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-005"
+    query: "Can I manage secrets from the Buildkite CLI?"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-006"
+    query: "I need to retry a failed build from the command line"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-007"
+    query: "How do I view job logs with bk job?"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-008"
+    query: "How do I list all pipelines in my org using the CLI?"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-009"
+    query: "Can I make a raw GraphQL query with bk api?"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  - id: "t-cli-010"
+    query: "How do I install bk on macOS?"
+    expected_skill: "buildkite-cli"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-CLI — near-miss (should NOT trigger cli)
+  # ============================================================
+
+  - id: "t-cli-n01"
+    query: "How do I download artifacts from within a running build step?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-runtime"]
+
+  - id: "t-cli-n02"
+    query: "How do I use buildkite-agent artifact download in my pipeline?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-runtime"]
+
+  - id: "t-cli-n03"
+    query: "How do I make a REST API call to Buildkite to list builds?"
+    expected_skill: "buildkite-platform"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-platform"]
+
+  - id: "t-cli-n04"
+    query: "How do I create a pipeline in my pipeline YAML using a trigger step?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-pipelines"]
+
+  - id: "t-cli-n05"
+    query: "How do I upload secrets to Buildkite using the agent's environment hook?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-agent"]
+
+  - id: "t-cli-n06"
+    query: "How do I install the buildkite-agent binary on Linux?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-agent"]
+
+  - id: "t-cli-n07"
+    query: "I want to cancel a step from within a running job using buildkite-agent step cancel"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-runtime"]
+
+  - id: "t-cli-n08"
+    query: "How do I use the Buildkite GraphQL explorer?"
+    expected_skill: "buildkite-platform"
+    expected_not_skills: ["buildkite-cli"]
+    tags: ["near-miss", "cli-vs-platform"]
+
+  # ============================================================
+  # BUILDKITE-AGENT-RUNTIME — should trigger
+  # ============================================================
+
+  - id: "t-runtime-001"
+    query: "How do I add an annotation to my build from within a step?"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-002"
+    query: "How do I upload artifacts from a running step?"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-003"
+    query: "I need to pass data between steps using buildkite-agent meta-data"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-004"
+    query: "How do I request an OIDC token inside a pipeline step?"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-005"
+    query: "What flags does buildkite-agent artifact upload accept?"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-006"
+    query: "how do i use buildkite-agent lock to coordinate between parallel jobs"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-007"
+    query: "I want to redact a secret from my build logs"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-008"
+    query: "How do I get the value of a step attribute using buildkite-agent step get?"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-009"
+    query: "How do I retrieve a cluster secret at runtime in my build?"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  - id: "t-runtime-010"
+    query: "How do I use buildkite-agent pipeline upload with --replace?"
+    expected_skill: "buildkite-agent-runtime"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-AGENT-RUNTIME — near-miss (should NOT trigger runtime)
+  # ============================================================
+
+  - id: "t-runtime-n01"
+    query: "How do I configure artifact paths in my pipeline YAML?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-pipelines"]
+
+  - id: "t-runtime-n02"
+    query: "How do I add annotations to my pipeline steps using the notify key?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-pipelines"]
+
+  - id: "t-runtime-n03"
+    query: "How do I download artifacts using bk artifact download from my laptop?"
+    expected_skill: "buildkite-cli"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-cli"]
+
+  - id: "t-runtime-n04"
+    query: "How do I configure the agent's environment hook to inject secrets?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-agent"]
+
+  - id: "t-runtime-n05"
+    query: "How do I set up OIDC trust policies in AWS for Buildkite?"
+    expected_skill: "buildkite-platform"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-platform"]
+
+  - id: "t-runtime-n06"
+    query: "How do I configure the agent to disconnect after being idle?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-agent"]
+
+  - id: "t-runtime-n07"
+    query: "I need to set environment variables globally across all my pipelines"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-agent"]
+
+  - id: "t-runtime-n08"
+    query: "How do I upload artifacts using the bk CLI after a build finishes?"
+    expected_skill: "buildkite-cli"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-cli"]
+
+  - id: "t-runtime-n09"
+    query: "How do I configure pipeline-level retry with automatic and manual options?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-pipelines"]
+
+  - id: "t-runtime-n10"
+    query: "How do I set up the test-collector plugin to upload JUnit XML?"
+    expected_skill: "buildkite-test-engine"
+    expected_not_skills: ["buildkite-agent-runtime"]
+    tags: ["near-miss", "runtime-vs-test-engine"]
+
+  # ============================================================
+  # BUILDKITE-TEST-ENGINE — should trigger
+  # ============================================================
+
+  - id: "t-test-001"
+    query: "How do I split my RSpec tests across parallel agents?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-002"
+    query: "How do I detect and quarantine flaky tests in Buildkite?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-003"
+    query: "how do i set up bktec for test splitting"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-004"
+    query: "How do I configure the test-collector plugin for Jest?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-005"
+    query: "My test suite is slow, how do I parallelize it with Buildkite Test Engine?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-006"
+    query: "What environment variables does bktec need?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-007"
+    query: "How do I create a test suite in Buildkite?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-008"
+    query: "bktec is falling back to running all tests instead of splitting. Why?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-009"
+    query: "How do I view test reliability scores and flaky test data?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  - id: "t-test-010"
+    query: "How do I set up automatic retry for flaky tests with BUILDKITE_TEST_ENGINE_RETRY_COUNT?"
+    expected_skill: "buildkite-test-engine"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-TEST-ENGINE — near-miss (should NOT trigger test-engine)
+  # ============================================================
+
+  - id: "t-test-n01"
+    query: "How do I add parallelism to my pipeline steps?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-pipelines"]
+
+  - id: "t-test-n02"
+    query: "How do I retry a failed build step automatically?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-pipelines"]
+
+  - id: "t-test-n03"
+    query: "How do I upload JUnit XML artifacts from my build step?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-runtime"]
+
+  - id: "t-test-n04"
+    query: "How do I speed up my pipeline by running steps in parallel?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-pipelines"]
+
+  - id: "t-test-n05"
+    query: "How do I configure test analytics in the Buildkite API?"
+    expected_skill: "buildkite-platform"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-platform"]
+
+  - id: "t-test-n06"
+    query: "My tests keep failing intermittently but it's a Docker networking issue"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-pipelines"]
+
+  - id: "t-test-n07"
+    query: "How do I retry a specific job from the Buildkite CLI?"
+    expected_skill: "buildkite-cli"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-cli"]
+
+  - id: "t-test-n08"
+    query: "How do I configure BUILDKITE_ANALYTICS_TOKEN in my agent's environment hook?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-test-engine"]
+    tags: ["near-miss", "test-engine-vs-agent"]
+
+  # ============================================================
+  # BUILDKITE-AGENT — should trigger
+  # ============================================================
+
+  - id: "t-agent-001"
+    query: "How do I install the Buildkite agent on Ubuntu?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-002"
+    query: "How do I configure agent tags and queue routing?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-003"
+    query: "How do I edit buildkite-agent.cfg?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-004"
+    query: "What's the difference between hosted and self-hosted agents?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-005"
+    query: "My agent is connected but not picking up any jobs"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-006"
+    query: "How do I set up clusters and manage agent tokens?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-007"
+    query: "How do I write an environment hook for my agent?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-008"
+    query: "How do I configure agent disconnect and idle timeout settings?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-009"
+    query: "How do I set up hosted agents with Docker-in-Docker support?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  - id: "t-agent-010"
+    query: "How do I add agent hooks when using agent-stack-k8s?"
+    expected_skill: "buildkite-agent"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-AGENT — near-miss (should NOT trigger agent)
+  # ============================================================
+
+  - id: "t-agent-n01"
+    query: "How do I use buildkite-agent meta-data set inside a step script?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-agent"]
+    tags: ["near-miss", "agent-vs-runtime"]
+
+  - id: "t-agent-n02"
+    query: "How do I use buildkite-agent annotate to add test failure summaries?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-agent"]
+    tags: ["near-miss", "agent-vs-runtime"]
+
+  - id: "t-agent-n03"
+    query: "How do I set the queue for a step in my pipeline YAML?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-agent"]
+    tags: ["near-miss", "agent-vs-pipelines"]
+
+  - id: "t-agent-n04"
+    query: "How do I configure agent token scoping via the REST API?"
+    expected_skill: "buildkite-platform"
+    expected_not_skills: ["buildkite-agent"]
+    tags: ["near-miss", "agent-vs-platform"]
+
+  - id: "t-agent-n05"
+    query: "How do I use buildkite-agent secret get to fetch a cluster secret at runtime?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-agent"]
+    tags: ["near-miss", "agent-vs-runtime"]
+
+  - id: "t-agent-n06"
+    query: "How do I use buildkite-agent env dump to debug environment variables?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-agent"]
+    tags: ["near-miss", "agent-vs-runtime"]
+
+  # ============================================================
+  # BUILDKITE-PLATFORM — should trigger
+  # ============================================================
+
+  - id: "t-platform-001"
+    query: "How do I use the Buildkite GraphQL API to query builds?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-002"
+    query: "What are the REST API rate limits?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-003"
+    query: "How do I set up a webhook to receive build notifications?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-004"
+    query: "How do I verify webhook signatures using HMAC?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-005"
+    query: "How do I set up SSO/SAML for my Buildkite organization?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-006"
+    query: "How do I scope API tokens for read-only access?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-007"
+    query: "How do I publish packages to the Buildkite Packages registry?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-008"
+    query: "How do I integrate Buildkite with an external notification system?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-009"
+    query: "I'm getting GraphQL query complexity errors, how do I fix them?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  - id: "t-platform-010"
+    query: "How do I set up OIDC token management for cloud provider authentication?"
+    expected_skill: "buildkite-platform"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-PLATFORM — near-miss (should NOT trigger platform)
+  # ============================================================
+
+  - id: "t-platform-n01"
+    query: "How do I use bk api to make a GraphQL query from the CLI?"
+    expected_skill: "buildkite-cli"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-cli"]
+
+  - id: "t-platform-n02"
+    query: "How do I request an OIDC token using buildkite-agent oidc request-token?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-runtime"]
+
+  - id: "t-platform-n03"
+    query: "How do I split tests using bktec?"
+    expected_skill: "buildkite-test-engine"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-test-engine"]
+
+  - id: "t-platform-n04"
+    query: "How do I add Slack notification to my pipeline YAML?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-pipelines"]
+
+  - id: "t-platform-n05"
+    query: "How do I manage agent tokens in agent-stack-k8s?"
+    expected_skill: "buildkite-agent"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-agent"]
+
+  - id: "t-platform-n06"
+    query: "How do I configure the test-collector plugin to send data to Test Engine?"
+    expected_skill: "buildkite-test-engine"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-test-engine"]
+
+  - id: "t-platform-n07"
+    query: "How do I list builds for a pipeline using the bk CLI?"
+    expected_skill: "buildkite-cli"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-cli"]
+
+  - id: "t-platform-n08"
+    query: "How do I use buildkite-agent tool sign to verify pipeline steps?"
+    expected_skill: "buildkite-agent-runtime"
+    expected_not_skills: ["buildkite-platform"]
+    tags: ["near-miss", "platform-vs-runtime"]


### PR DESCRIPTION
## Summary
- Adds `run_trigger.py` — tests whether Claude routes user queries to the correct skill based on descriptions alone
- Creates `trigger_dataset.yaml` with 110 evals (60 should-trigger + 50 near-miss) across all 6 skills
- Extends `lib/` with trigger grading, dataset loading, and reporting (including confusion matrix)
- Documents trigger evals alongside existing quality evals in README

## How it works
Presents all skill descriptions in a system prompt, sends the query, asks the model to return `{"skill": "<name>"}`. Grades whether the correct skill was selected.

## Key metrics
- Per-skill precision, recall, F1
- Confusion matrix (expected vs selected)
- Multi-run trigger rates (`--runs 3`)
- Holdout split for description tuning validation

## First run results
98.2% accuracy (108/110) — only 2 failures on ambiguous boundary queries.

## Test plan
- [x] `python evals/run_trigger.py` — all 110 evals pass through runner
- [x] `python evals/run_trigger.py --skill buildkite-pipelines` — filtering works
- [x] `python evals/run_trigger.py --tag near-miss` — tag filtering works
- [x] Confusion matrix renders with correct alignment
- [x] Existing quality evals unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)