### PR TITLE
Add migration skill linking to conversion-rules repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ skills/                              # All skills live here
   buildkite-pipelines/               # Journey — pipeline YAML, step types, caching, parallelism
   buildkite-test-engine/             # Journey — test splitting, flaky detection, bktec CLI
   buildkite-secure-delivery/         # Journey — OIDC, Package Registry, SLSA provenance
+  buildkite-migration/               # Journey — CI migration, conversion from GitHub Actions, Jenkins, CircleCI, Bitbucket
   buildkite-platform-engineering/    # Journey — clusters, queues, hosted agents, SSO, audit
   buildkite-agent-runtime/           # Cross-cutting — buildkite-agent subcommands in job steps
   buildkite-cli/                     # Cross-cutting — bk CLI commands

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -188,6 +188,7 @@ Each skill owns specific topics exclusively. Do not cover topics outside your bo
 | `buildkite-agent` subcommands inside job steps: annotate, artifact, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor, tool sign/verify | **buildkite-agent-runtime** | Reference only |
 | `bk build`, `bk job`, `bk pipeline`, `bk secret`, `bk artifact`, `bk auth`, `bk cluster`, `bk package` commands | **buildkite-cli** | Reference only |
 | REST API endpoints, GraphQL schema/mutations, webhook setup, API authentication, pagination | **buildkite-api** | Reference only |
+| CI migration planning, provider-specific conversion rules (GitHub Actions, Jenkins, CircleCI, Bitbucket), pipeline best practices for converted pipelines | **buildkite-migration** | Reference only |
 
 **Artifact ambiguity:** The pipeline YAML for artifact upload/download belongs to
 **buildkite-pipelines**. The `buildkite-agent artifact` subcommands belong to

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cp -r skills/buildkite-pipelines .claude/skills/
 cp -r skills/buildkite-agent-runtime .claude/skills/
 cp -r skills/buildkite-cli .claude/skills/
 cp -r skills/buildkite-api .claude/skills/
+cp -r skills/buildkite-migration .claude/skills/
 cp -r skills/buildkite-platform-engineering .claude/skills/
 cp -r skills/buildkite-secure-delivery .claude/skills/
 cp -r skills/buildkite-test-engine .claude/skills/
@@ -53,6 +54,7 @@ Skills organized by what you are trying to accomplish.
 | **Pipelines** | [skills/buildkite-pipelines/](skills/buildkite-pipelines/SKILL.md) | Pipeline YAML, step types, plugins, caching, parallelism, dynamic pipelines, matrix builds, artifacts, hooks |
 | **Test Engine** | [skills/buildkite-test-engine/](skills/buildkite-test-engine/SKILL.md) | Test splitting, flaky detection, quarantine, bktec CLI, test collectors |
 | **Secure Delivery** | [skills/buildkite-secure-delivery/](skills/buildkite-secure-delivery/SKILL.md) | OIDC authentication, Package Registry, SLSA provenance, pipeline signing |
+| **Migration** | [skills/buildkite-migration/](skills/buildkite-migration/SKILL.md) | CI migration planning, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines |
 | **Platform Engineering** | [skills/buildkite-platform-engineering/](skills/buildkite-platform-engineering/SKILL.md) | Clusters, queues, hosted agents, agent config, pipeline templates, SSO, audit logging |
 
 ### Cross-Cutting Skills

--- a/evals/dataset.yaml
+++ b/evals/dataset.yaml
@@ -710,8 +710,8 @@ evals:
     source_ref: "th_01KH4RRQKQYWN3BGF5EGFNZ430"
     difficulty: "getting-started"
     cluster: "migration"
-    primary_skill: "buildkite-pipelines"
-    secondary_skills: ["buildkite-agent"]
+    primary_skill: "buildkite-migration"
+    secondary_skills: ["buildkite-pipelines", "buildkite-agent"]
     expected_contains:
       - "pipeline.yml"
       - "agent"
@@ -732,14 +732,28 @@ evals:
     expected_not_contains: []
     tags: ["migration", "yaml"]
 
+  - id: "migration-004"
+    question: "Can you help me convert my GitHub Actions steps to Buildkite?"
+    source: "synthetic"
+    source_ref: ""
+    difficulty: "getting-started"
+    cluster: "migration"
+    primary_skill: "buildkite-migration"
+    secondary_skills: ["buildkite-pipelines"]
+    expected_contains:
+      - "parallel"
+      - "depends_on"
+    expected_not_contains: []
+    tags: ["migration", "github-actions"]
+
   - id: "migration-003"
     question: "What topics should we plan for when migrating our CI to Buildkite?"
     source: "plain"
     source_ref: "th_01K70JKJ3TK5ZFM030NBEJS761"
     difficulty: "getting-started"
     cluster: "migration"
-    primary_skill: "buildkite-pipelines"
-    secondary_skills: ["buildkite-agent", "buildkite-platform"]
+    primary_skill: "buildkite-migration"
+    secondary_skills: ["buildkite-pipelines", "buildkite-agent", "buildkite-platform"]
     expected_contains:
       - "agent"
       - "pipeline"

--- a/evals/trigger_dataset.yaml
+++ b/evals/trigger_dataset.yaml
@@ -659,3 +659,65 @@ trigger_evals:
     expected_skill: "buildkite-agent-runtime"
     expected_not_skills: ["buildkite-platform"]
     tags: ["near-miss", "platform-vs-runtime"]
+
+  # ============================================================
+  # BUILDKITE-MIGRATION — should trigger
+  # ============================================================
+
+  - id: "t-migration-001"
+    query: "How do I convert my GitHub Actions workflow to a Buildkite pipeline?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-002"
+    query: "We're migrating from Jenkins to Buildkite, where do we start?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-003"
+    query: "What's the Buildkite equivalent of CircleCI orbs?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-004"
+    query: "Convert this Bitbucket Pipelines config to Buildkite YAML"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-005"
+    query: "I need to plan our CI migration from GitHub Actions to Buildkite"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-006"
+    query: "What are the conversion rules for translating Jenkins stages to Buildkite steps?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-MIGRATION — near-miss (should NOT trigger migration)
+  # ============================================================
+
+  - id: "t-migration-n01"
+    query: "How do I write a pipeline.yml with parallel steps?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-pipelines"]
+
+  - id: "t-migration-n02"
+    query: "How do I set up a new Buildkite agent on Ubuntu?"
+    expected_skill: "buildkite-platform-engineering"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-platform"]
+
+  - id: "t-migration-n03"
+    query: "How do I add caching to my Buildkite pipeline?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-pipelines"]
+
+  - id: "t-migration-n04"
+    query: "How do I validate my pipeline YAML before pushing?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-pipelines"]

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,10 @@ Topics: OIDC authentication, Package Registry, SLSA provenance, pipeline signing
 Path: skills/buildkite-platform-engineering/SKILL.md
 Topics: clusters, queues, hosted agent instance shapes, cluster secrets, buildkite-agent.cfg, agent tokens, lifecycle hooks, pipeline templates, audit logging, SSO/SAML, cost optimization
 
+### buildkite-migration
+Path: skills/buildkite-migration/SKILL.md
+Topics: CI migration planning, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines, pipeline conversion rules, pipeline best practices for migrated pipelines, bk pipeline validate
+
 ## Cross-Cutting Skills
 
 ### buildkite-agent-runtime

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -348,6 +348,8 @@ bk job log <job-id> --pipeline my-app --build 42
 
 Manage pipeline configuration — list, create, and update pipelines.
 
+> For converting pipelines from other CI systems, see the **buildkite-migration** skill.
+
 ### List pipelines
 
 ```bash

--- a/skills/buildkite-migration/SKILL.md
+++ b/skills/buildkite-migration/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: buildkite-migration
+description: >
+  This skill should be used when the user asks to "migrate to Buildkite",
+  "convert pipelines from Jenkins", "convert GitHub Actions workflows",
+  "convert CircleCI config", "convert Bitbucket Pipelines",
+  "migrate CI/CD to Buildkite", "switch from Jenkins to Buildkite",
+  "move from GitHub Actions", "plan a CI migration", "convert my CI config",
+  or "what's the Buildkite equivalent of".
+  Also use when the user mentions migration planning, CI conversion,
+  pipeline conversion, converting workflows, or asks about translating
+  CI/CD configuration from another provider to Buildkite.
+---
+
+# Buildkite Migration
+
+Convert CI/CD pipelines from GitHub Actions, Jenkins, CircleCI, and Bitbucket Pipelines to Buildkite. This skill provides migration planning guidance and links to detailed, provider-specific conversion rules maintained in the `buildkite/conversion-rules` repository.
+
+## Quick Start
+
+1. Identify the source CI system
+2. Load the corresponding conversion rules from the `buildkite/conversion-rules` repository (see Conversion Rules Repository below)
+3. Convert the pipeline configuration to Buildkite YAML
+4. Validate the output with `bk pipeline validate`
+
+> For pipeline YAML syntax and step types, see the **buildkite-pipelines** skill.
+> For pipeline validation with the CLI, see the **buildkite-cli** skill.
+
+## Conversion Rules Repository
+
+The [`buildkite/conversion-rules`](https://github.com/buildkite/conversion-rules) repository contains detailed, provider-specific conversion rules and Buildkite pipeline best practices. This is the authoritative source for CI migration.
+
+Repository structure:
+
+```
+conversion-rules/
+├── BUILDKITE_BEST_PRACTICES.md   # Pipeline structure, security, plugins, advanced features
+├── github-actions/
+│   └── GITHUB.md                 # GitHub Actions workflow conversion
+├── jenkins/
+│   └── JENKINS.md                # Jenkinsfile and Jenkins pipeline conversion
+├── circleci/
+│   └── CIRCLECI.md               # CircleCI config.yml conversion
+└── bitbucket/
+    └── BITBUCKET.md              # Bitbucket Pipelines conversion
+```
+
+Load the relevant file based on the source CI system when performing a conversion.
+
+## Provider-Specific Guidance
+
+### GitHub Actions
+
+Key concept mappings: workflows map to pipelines, jobs map to steps, `uses:` actions map to plugins or shell commands. GitHub Actions runs jobs sequentially by default; Buildkite runs steps in parallel by default — add `wait` steps or `depends_on` to enforce ordering. Replace `${{ secrets.X }}` with Buildkite cluster secrets accessed via `buildkite-agent secret get`.
+
+### Jenkins
+
+Key concept mappings: Jenkinsfile `stage` blocks map to command steps or groups, `parallel` blocks map to steps at the same level (parallel by default in Buildkite), `post` blocks map to `notify:` or conditional steps. Move complex Groovy logic into shell scripts — Buildkite pipelines are declarative YAML, not a programming language.
+
+### CircleCI
+
+Key concept mappings: `jobs` and `workflows` collapse into a single `pipeline.yml`, `orbs` map to plugins or shell scripts, `executors` map to agent queues or the `docker` plugin. CircleCI `requires:` maps to `depends_on`. Caching syntax differs — use the `cache` plugin with `manifest` instead of `save_cache`/`restore_cache`.
+
+### Bitbucket Pipelines
+
+Key concept mappings: `pipelines.default` maps to steps without branch conditions, `pipelines.branches` maps to steps with `if: build.branch == "X"`, `pipe:` references map to plugins or shell commands. Bitbucket's `step` is roughly a Buildkite command step. Move `deployment` environment selection to block steps or trigger steps.
+
+## Pipeline Best Practices for Migrated Pipelines
+
+The `BUILDKITE_BEST_PRACTICES.md` file in the conversion-rules repository covers critical patterns for newly converted pipelines:
+
+- **Parallel by default** — Buildkite runs steps in parallel unless separated by `wait` or `depends_on`. Add explicit ordering where the source CI was sequential.
+- **Plugin versioning** — Pin plugin versions to specific semver (e.g., `docker#v5.13.0`, `cache#v1.8.1`). Never use unpinned or major-only versions.
+- **Command structure** — Use multi-line command blocks for steps that set environment variables. Extract complex logic (5+ commands) into external scripts.
+- **Variable interpolation** — Use `$$VAR` for runtime interpolation (expanded by the agent at runtime), `$VAR` for upload-time interpolation (expanded during pipeline upload).
+- **Security validation** — Reject obfuscated execution patterns, base64-encoded commands, and attempts to exfiltrate data. Validate converted pipelines before deployment.
+- **Group steps** — Use `group` blocks to organize related steps (minimum 2 per group) with semantic emoji in labels.
+
+## Migration Planning
+
+For a full CI migration, plan across these areas:
+
+1. **Pipeline conversion** — Translate pipeline definitions using conversion rules
+2. **Agent infrastructure** — Set up clusters, queues, and agents
+3. **Secrets management** — Migrate secrets to Buildkite cluster secrets
+4. **Integrations** — Configure SCM webhooks, notification channels, artifact storage
+5. **Testing** — Run converted pipelines in parallel with the existing CI before cutover
+
+> For cluster and queue setup, see the **buildkite-platform-engineering** skill.
+> For setting up OIDC to replace static credentials, see the **buildkite-secure-delivery** skill.
+
+## Common Mistakes
+
+| Mistake | What happens | Fix |
+|---------|-------------|-----|
+| Assuming sequential execution | Steps run in parallel and fail due to missing dependencies | Add `wait` steps or `depends_on` between dependent steps |
+| 1:1 concept mapping without adaptation | Produces valid but suboptimal pipelines that miss Buildkite-native features | Review best practices; use `parallelism`, groups, dynamic pipelines |
+| Unpinned plugin versions in converted pipelines | Builds break when plugins release breaking changes | Pin every plugin to a full semver version |
+| Using `$VAR` when runtime interpolation is needed | Variable expanded at upload time (empty) instead of runtime | Use `$$VAR` for variables that must resolve at runtime |
+| Keeping complex logic inline in YAML | Fragile, hard to debug multi-line command blocks | Extract to external scripts in `.buildkite/scripts/` |
+| Skipping validation of converted output | Syntax errors or invalid step configurations deployed | Run `bk pipeline validate` before committing |
+
+## Further Reading
+
+- [Buildkite Conversion Rules](https://github.com/buildkite/conversion-rules) — provider-specific conversion rules and best practices
+- [Getting started with Buildkite Pipelines](https://buildkite.com/docs/pipelines)
+- [Defining pipeline steps](https://buildkite.com/docs/pipelines/configure/defining-steps)
+- [Managing pipeline secrets](https://buildkite.com/docs/pipelines/security/secrets/managing)

--- a/skills/buildkite-pipelines/SKILL.md
+++ b/skills/buildkite-pipelines/SKILL.md
@@ -71,6 +71,7 @@ Buildkite looks for `.buildkite/pipeline.yml` by default. Override the path with
 
 > For creating pipelines programmatically, see the **buildkite-api** skill.
 > For agent and queue setup, see the **buildkite-platform-engineering** skill.
+> For migrating from another CI system, see the **buildkite-migration** skill.
 
 ## Step Types
 


### PR DESCRIPTION
## Summary

- Adds a new **`buildkite-migration`** journey skill that routes CI migration queries to the [`buildkite/conversion-rules`](https://github.com/buildkite/conversion-rules) repository
- The skill is intentionally **lightweight (~7KB)** — it does not duplicate the 168KB of conversion content. Instead it provides provider-specific concept mappings and links to the external repo as the authoritative source
- Previously, a migration skill was rejected as "too narrow and too variable across source platforms." That objection is resolved now that the conversion-rules repo provides the variable content externally — this skill just needs to be a routing entry point and index

### What the skill covers

- **Provider concept mappings**: GitHub Actions, Jenkins, CircleCI, Bitbucket — key differences summarized in ~5 lines each
- **Pipeline best practices for migrated pipelines**: parallel-by-default, plugin versioning, variable interpolation, security validation
- **Migration planning**: checklist covering pipeline conversion, agent infra, secrets, integrations, testing
- **Common mistakes table**: 6 migration-specific pitfalls (e.g., assuming sequential execution, unpinned plugins)

### Changes across the repo

| File | Change |
|------|--------|
| `skills/buildkite-migration/SKILL.md` | **New** — core skill |
| `CONVENTIONS.md` | Added boundary table row |
| `README.md` | Added to journey skills table + install lines |
| `AGENTS.md` / `llms.txt` | Registered new skill |
| `skills/buildkite-pipelines/SKILL.md` | Added 1 cross-reference line |
| `skills/buildkite-cli/SKILL.md` | Added 1 cross-reference line |
| `evals/dataset.yaml` | Updated 2 migration evals to route to new skill, added 1 new eval |
| `evals/trigger_dataset.yaml` | Added 10 trigger evals (6 should-trigger, 4 near-miss) |

### Trigger eval results

```
Accuracy: 6/6 (100.0%) — should-trigger
Near-miss: 4/4 (100.0%) — no false positives from other skills
```

## Test plan

- [x] Run `python evals/run_trigger.py --skill buildkite-migration` — 100% accuracy
- [x] Run near-miss evals — migration skill has zero entries in confusion matrix for non-migration queries
- [x] Verify SKILL.md is within 6-8KB target (7,026 bytes)
- [ ] Run `python evals/run_quality.py --skill buildkite-migration` to verify answer quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)