### PR TITLE
Add buildkite-migration skill with bk pipeline convert

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ skills/                              # All skills live here
   buildkite-pipelines/               # Journey — pipeline YAML, step types, caching, parallelism
   buildkite-test-engine/             # Journey — test splitting, flaky detection, bktec CLI
   buildkite-secure-delivery/         # Journey — OIDC, Package Registry, SLSA provenance
+  buildkite-migration/               # Journey — CI migration, bk pipeline convert, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket, GitLab CI
   buildkite-platform-engineering/    # Journey — clusters, queues, hosted agents, SSO, audit
   buildkite-agent-runtime/           # Cross-cutting — buildkite-agent subcommands in job steps
   buildkite-cli/                     # Cross-cutting — bk CLI commands

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -186,7 +186,7 @@ Each skill owns specific topics exclusively. Do not cover topics outside your bo
 | OIDC auth flows, Package Registry setup, SLSA provenance, pipeline signing (JWKS), verification rollout | **buildkite-secure-delivery** | Reference only |
 | Clusters, queues, hosted agent instance shapes, cluster secrets, `buildkite-agent.cfg`, agent tokens, lifecycle hooks, pipeline templates, audit logging, SSO/SAML, cost optimization | **buildkite-platform-engineering** | Reference only |
 | `buildkite-agent` subcommands inside job steps: annotate, artifact, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor, tool sign/verify | **buildkite-agent-runtime** | Reference only |
-| `bk build`, `bk job`, `bk pipeline`, `bk secret`, `bk artifact`, `bk auth`, `bk cluster`, `bk package` commands | **buildkite-cli** | Reference only |
+| `bk build`, `bk job`, `bk pipeline`, `bk pipeline convert`, `bk secret`, `bk artifact`, `bk auth`, `bk cluster`, `bk package` commands | **buildkite-cli** | Reference only |
 | REST API endpoints, GraphQL schema/mutations, webhook setup, API authentication, pagination | **buildkite-api** | Reference only |
 | CI migration planning, `bk pipeline convert`, provider-specific concept mappings (GitHub Actions, Jenkins, CircleCI, Bitbucket, GitLab CI), pipeline best practices for converted pipelines | **buildkite-migration** | Reference only |
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -188,6 +188,7 @@ Each skill owns specific topics exclusively. Do not cover topics outside your bo
 | `buildkite-agent` subcommands inside job steps: annotate, artifact, meta-data, pipeline upload, oidc, step, lock, env, secret, redactor, tool sign/verify | **buildkite-agent-runtime** | Reference only |
 | `bk build`, `bk job`, `bk pipeline`, `bk secret`, `bk artifact`, `bk auth`, `bk cluster`, `bk package` commands | **buildkite-cli** | Reference only |
 | REST API endpoints, GraphQL schema/mutations, webhook setup, API authentication, pagination | **buildkite-api** | Reference only |
+| CI migration planning, `bk pipeline convert`, provider-specific concept mappings (GitHub Actions, Jenkins, CircleCI, Bitbucket, GitLab CI), pipeline best practices for converted pipelines | **buildkite-migration** | Reference only |
 
 **Artifact ambiguity:** The pipeline YAML for artifact upload/download belongs to
 **buildkite-pipelines**. The `buildkite-agent artifact` subcommands belong to

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cp -r skills/buildkite-pipelines .claude/skills/
 cp -r skills/buildkite-agent-runtime .claude/skills/
 cp -r skills/buildkite-cli .claude/skills/
 cp -r skills/buildkite-api .claude/skills/
+cp -r skills/buildkite-migration .claude/skills/
 cp -r skills/buildkite-platform-engineering .claude/skills/
 cp -r skills/buildkite-secure-delivery .claude/skills/
 cp -r skills/buildkite-test-engine .claude/skills/
@@ -37,6 +38,7 @@ cp -r skills/buildkite-pipelines .cursor/skills/
 cp -r skills/buildkite-agent-runtime .cursor/skills/
 cp -r skills/buildkite-cli .cursor/skills/
 cp -r skills/buildkite-api .cursor/skills/
+cp -r skills/buildkite-migration .cursor/skills/
 cp -r skills/buildkite-platform-engineering .cursor/skills/
 cp -r skills/buildkite-secure-delivery .cursor/skills/
 cp -r skills/buildkite-test-engine .cursor/skills/
@@ -53,6 +55,7 @@ Skills organized by what you are trying to accomplish.
 | **Pipelines** | [skills/buildkite-pipelines/](skills/buildkite-pipelines/SKILL.md) | Pipeline YAML, step types, plugins, caching, parallelism, dynamic pipelines, matrix builds, artifacts, hooks |
 | **Test Engine** | [skills/buildkite-test-engine/](skills/buildkite-test-engine/SKILL.md) | Test splitting, flaky detection, quarantine, bktec CLI, test collectors |
 | **Secure Delivery** | [skills/buildkite-secure-delivery/](skills/buildkite-secure-delivery/SKILL.md) | OIDC authentication, Package Registry, SLSA provenance, pipeline signing |
+| **Migration** | [skills/buildkite-migration/](skills/buildkite-migration/SKILL.md) | CI migration planning, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines, GitLab CI using `bk pipeline convert` |
 | **Platform Engineering** | [skills/buildkite-platform-engineering/](skills/buildkite-platform-engineering/SKILL.md) | Clusters, queues, hosted agents, agent config, pipeline templates, SSO, audit logging |
 
 ### Cross-Cutting Skills

--- a/evals/dataset.yaml
+++ b/evals/dataset.yaml
@@ -710,8 +710,8 @@ evals:
     source_ref: "th_01KH4RRQKQYWN3BGF5EGFNZ430"
     difficulty: "getting-started"
     cluster: "migration"
-    primary_skill: "buildkite-pipelines"
-    secondary_skills: ["buildkite-agent"]
+    primary_skill: "buildkite-migration"
+    secondary_skills: ["buildkite-pipelines", "buildkite-agent"]
     expected_contains:
       - "pipeline.yml"
       - "agent"
@@ -738,14 +738,28 @@ evals:
     source_ref: "th_01K70JKJ3TK5ZFM030NBEJS761"
     difficulty: "getting-started"
     cluster: "migration"
-    primary_skill: "buildkite-pipelines"
-    secondary_skills: ["buildkite-agent", "buildkite-platform"]
+    primary_skill: "buildkite-migration"
+    secondary_skills: ["buildkite-pipelines", "buildkite-agent", "buildkite-platform"]
     expected_contains:
       - "agent"
       - "pipeline"
       - "secrets"
     expected_not_contains: []
     tags: ["migration", "architecture", "cross-skill"]
+
+  - id: "migration-004"
+    question: "Can you help me convert my GitHub Actions steps to Buildkite?"
+    source: "synthetic"
+    source_ref: ""
+    difficulty: "getting-started"
+    cluster: "migration"
+    primary_skill: "buildkite-migration"
+    secondary_skills: ["buildkite-pipelines"]
+    expected_contains:
+      - "bk pipeline convert"
+      - "github"
+    expected_not_contains: []
+    tags: ["migration", "github-actions"]
 
   # ============================================================
   # SECRETS & SECURITY

--- a/evals/trigger_dataset.yaml
+++ b/evals/trigger_dataset.yaml
@@ -659,3 +659,70 @@ trigger_evals:
     expected_skill: "buildkite-agent-runtime"
     expected_not_skills: ["buildkite-platform"]
     tags: ["near-miss", "platform-vs-runtime"]
+
+  # ============================================================
+  # BUILDKITE-MIGRATION — should trigger
+  # ============================================================
+
+  - id: "t-migration-001"
+    query: "How do I convert my GitHub Actions workflow to a Buildkite pipeline?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-002"
+    query: "We're migrating from Jenkins to Buildkite, where do we start?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-003"
+    query: "What's the Buildkite equivalent of CircleCI orbs?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-004"
+    query: "Convert this Bitbucket Pipelines config to Buildkite YAML"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-005"
+    query: "I need to plan our CI migration from GitHub Actions to Buildkite"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-006"
+    query: "What are the conversion rules for translating Jenkins stages to Buildkite steps?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  - id: "t-migration-007"
+    query: "How do I use bk pipeline convert to migrate my GitLab CI config?"
+    expected_skill: "buildkite-migration"
+    tags: ["should-trigger"]
+
+  # ============================================================
+  # BUILDKITE-MIGRATION — near-miss (should NOT trigger migration)
+  # ============================================================
+
+  - id: "t-migration-n01"
+    query: "How do I write a pipeline.yml with parallel steps?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-pipelines"]
+
+  - id: "t-migration-n02"
+    query: "How do I set up a new Buildkite agent on Ubuntu?"
+    expected_skill: "buildkite-platform-engineering"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-platform"]
+
+  - id: "t-migration-n03"
+    query: "How do I add caching to my Buildkite pipeline?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-pipelines"]
+
+  - id: "t-migration-n04"
+    query: "How do I validate my pipeline YAML before pushing?"
+    expected_skill: "buildkite-pipelines"
+    expected_not_skills: ["buildkite-migration"]
+    tags: ["near-miss", "migration-vs-pipelines"]

--- a/llms.txt
+++ b/llms.txt
@@ -34,7 +34,7 @@ Topics: buildkite-agent annotate, artifact upload/download, meta-data set/get, p
 
 ### buildkite-cli
 Path: skills/buildkite-cli/SKILL.md
-Topics: bk build create/list/view/watch, bk job log/retry/cancel, bk pipeline, bk secret, bk artifact, bk cluster, bk package, bk auth, bk configure, bk init
+Topics: bk build create/list/view/watch, bk job log/retry/cancel, bk pipeline, bk pipeline convert, bk secret, bk artifact, bk cluster, bk package, bk auth, bk configure, bk init
 
 ### buildkite-api
 Path: skills/buildkite-api/SKILL.md

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,10 @@ Topics: OIDC authentication, Package Registry, SLSA provenance, pipeline signing
 Path: skills/buildkite-platform-engineering/SKILL.md
 Topics: clusters, queues, hosted agent instance shapes, cluster secrets, buildkite-agent.cfg, agent tokens, lifecycle hooks, pipeline templates, audit logging, SSO/SAML, cost optimization
 
+### buildkite-migration
+Path: skills/buildkite-migration/SKILL.md
+Topics: CI migration planning, bk pipeline convert, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines, GitLab CI, vendor auto-detection, pipeline best practices for migrated pipelines
+
 ## Cross-Cutting Skills
 
 ### buildkite-agent-runtime

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -350,6 +350,33 @@ Manage pipeline configuration — list, create, and update pipelines.
 
 > For converting pipelines from other CI systems, see the **buildkite-migration** skill.
 
+### Convert a pipeline from another CI system
+
+Convert a GitHub Actions, Jenkins, CircleCI, Bitbucket, GitLab, Harness, or Bitrise pipeline to Buildkite YAML. No login required — uses a public API.
+
+```bash
+# Auto-detect vendor from file path and save to .buildkite/pipeline.<vendor>.yml
+bk pipeline convert -F .github/workflows/ci.yml
+bk pipeline convert -F .circleci/config.yml
+bk pipeline convert -F Jenkinsfile
+
+# Specify vendor explicitly (required for gitlab, harness, bitrise)
+bk pipeline convert -F .gitlab-ci.yml --vendor gitlab
+
+# Custom output path
+bk pipeline convert -F .github/workflows/ci.yml --output .buildkite/pipeline.yml
+
+# Read from stdin
+cat .github/workflows/ci.yml | bk pipeline convert --vendor github
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--file` | `-F` | — | Path to source pipeline file (required unless using stdin) |
+| `--vendor` | `-v` | auto-detected | Source CI vendor: `github`, `bitbucket`, `circleci`, `jenkins`, `gitlab`, `harness`, `bitrise` |
+| `--output` | `-o` | `.buildkite/pipeline.<vendor>.yml` | Output file path |
+| `--timeout` | — | `300` | Cancellation timeout in seconds |
+
 ### List pipelines
 
 ```bash

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -348,6 +348,8 @@ bk job log <job-id> --pipeline my-app --build 42
 
 Manage pipeline configuration — list, create, and update pipelines.
 
+> For converting pipelines from other CI systems, see the **buildkite-migration** skill.
+
 ### List pipelines
 
 ```bash

--- a/skills/buildkite-migration/SKILL.md
+++ b/skills/buildkite-migration/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: buildkite-migration
+description: >
+  This skill should be used when the user asks to "migrate to Buildkite",
+  "convert pipelines from Jenkins", "convert GitHub Actions workflows",
+  "convert CircleCI config", "convert Bitbucket Pipelines", "convert GitLab CI",
+  "migrate CI/CD to Buildkite", "switch from Jenkins to Buildkite",
+  "move from GitHub Actions", "plan a CI migration", "convert my CI config",
+  "bk pipeline convert", or "what's the Buildkite equivalent of".
+  Also use when the user mentions migration planning, CI conversion,
+  pipeline conversion, converting workflows, or asks about translating
+  CI/CD configuration from another provider to Buildkite.
+---
+
+# Buildkite Migration
+
+Convert CI/CD pipelines from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines, and GitLab CI to Buildkite using the `bk pipeline convert` command. The command sends the source file to a public conversion API — no Buildkite account or API token is required.
+
+## Quick Start
+
+```bash
+# 1. Install the bk CLI (no login needed for convert)
+brew tap buildkite/buildkite && brew install buildkite/buildkite/bk
+
+# 2. Convert the source pipeline file
+bk pipeline convert -F .github/workflows/ci.yml
+
+# 3. Find the output in .buildkite/pipeline.github.yml
+```
+
+> For pipeline YAML syntax and step types, see the **buildkite-pipelines** skill.
+> For other bk CLI commands, see the **buildkite-cli** skill.
+
+## Agent Workflow
+
+When a user provides a pipeline file or pastes pipeline content to convert:
+
+1. Write the content to a temp file (e.g. `/tmp/.github/workflows/ci.yml` for GitHub Actions so vendor auto-detection works)
+2. Run `bk pipeline convert -F <tempfile> --output <output-path>`
+3. Read the output file and display it as a YAML code block — nothing else
+4. Do not summarise, annotate, or critique the output unless the user explicitly asks for feedback
+
+## Converting with `bk pipeline convert`
+
+### Installation
+
+```bash
+# macOS and Linux (Homebrew)
+brew tap buildkite/buildkite && brew install buildkite/buildkite/bk
+
+# Or download a binary from https://github.com/buildkite/cli/releases
+```
+
+No `bk auth login` is needed — the convert command uses a public API.
+
+### Basic usage
+
+```bash
+bk pipeline convert -F <source-file>
+```
+
+The vendor is auto-detected from the file path for the four main providers. Output is saved to `.buildkite/pipeline.<vendor>.yml`.
+
+### Supported vendors
+
+| Vendor flag | Source CI | Auto-detected from |
+|-------------|-----------|-------------------|
+| `github` | GitHub Actions | `.github/workflows/` path |
+| `circleci` | CircleCI | `.circleci/` path |
+| `jenkins` | Jenkins | `Jenkinsfile` filename |
+| `bitbucket` | Bitbucket Pipelines | `bitbucket-pipelines.yml` filename |
+| `gitlab` | GitLab CI (beta) | not auto-detected |
+| `harness` | Harness CI (beta) | not auto-detected |
+| `bitrise` | Bitrise (beta) | not auto-detected |
+
+### Provider examples
+
+```bash
+# GitHub Actions (auto-detected from path)
+bk pipeline convert -F .github/workflows/ci.yml
+
+# CircleCI (auto-detected)
+bk pipeline convert -F .circleci/config.yml
+
+# Jenkins (auto-detected)
+bk pipeline convert -F Jenkinsfile
+
+# Bitbucket Pipelines (auto-detected)
+bk pipeline convert -F bitbucket-pipelines.yml
+
+# GitLab CI (explicit vendor required)
+bk pipeline convert -F .gitlab-ci.yml --vendor gitlab
+```
+
+### Output options
+
+```bash
+# Default: saves to .buildkite/pipeline.<vendor>.yml
+bk pipeline convert -F .github/workflows/ci.yml
+
+# Custom output path
+bk pipeline convert -F .github/workflows/ci.yml --output .buildkite/pipeline.yml
+
+# Pipe from stdin (--vendor required)
+cat .github/workflows/ci.yml | bk pipeline convert --vendor github
+
+# Read from stdin with file redirect
+bk pipeline convert --vendor circleci < .circleci/config.yml
+```
+
+### Flags
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--file` | `-F` | Path to source pipeline file | — (required unless using stdin) |
+| `--vendor` | `-v` | CI vendor; auto-detected if omitted | — |
+| `--output` | `-o` | Output file path | `.buildkite/pipeline.<vendor>.yml` |
+| `--timeout` | — | Cancellation timeout in seconds | `300` |
+
+## Provider-Specific Guidance
+
+Review the converted output against these concept mappings before committing.
+
+### GitHub Actions
+
+Key concept mappings: workflows map to pipelines, jobs map to steps, `uses:` actions map to plugins or shell commands. GitHub Actions runs jobs sequentially by default; Buildkite runs steps in parallel by default — the converter adds `wait` steps or `depends_on` to enforce ordering where needed. Replace `${{ secrets.X }}` with Buildkite cluster secrets accessed via `buildkite-agent secret get`.
+
+### Jenkins
+
+Key concept mappings: Jenkinsfile `stage` blocks map to command steps or groups, `parallel` blocks map to steps at the same level (parallel by default in Buildkite), `post` blocks map to `notify:` or conditional steps. Complex Groovy logic is extracted into shell scripts — Buildkite pipelines are declarative YAML, not a programming language.
+
+### CircleCI
+
+Key concept mappings: `jobs` and `workflows` collapse into a single `pipeline.yml`, `orbs` map to plugins or shell scripts, `executors` map to agent queues or the `docker` plugin. CircleCI `requires:` maps to `depends_on`. Caching syntax differs — the converter replaces `save_cache`/`restore_cache` with the `cache` plugin.
+
+### Bitbucket Pipelines
+
+Key concept mappings: `pipelines.default` maps to steps without branch conditions, `pipelines.branches` maps to steps with `if: build.branch == "X"`, `pipe:` references map to plugins or shell commands. The Bitbucket `step` is roughly equivalent to a Buildkite command step.
+
+### GitLab CI
+
+Key concept mappings: stages and jobs collapse into Buildkite steps with `depends_on`, `.gitlab-ci.yml` `extends:` maps to YAML anchors, `rules:` map to `if:` conditions. GitLab's `artifacts:` maps to Buildkite's `artifact_paths`.
+
+## Pipeline Best Practices for Migrated Pipelines
+
+After conversion, review the output against these patterns:
+
+- **Parallel by default** — Buildkite runs steps in parallel unless separated by `wait` or `depends_on`. Verify the converted ordering matches the original CI's intent.
+- **Plugin versioning** — Pin plugin versions to full semver (e.g., `docker#v5.13.0`, `cache#v1.8.1`). Never use unpinned or major-only versions.
+- **Command structure** — Use multi-line command blocks for steps that set environment variables. Extract complex logic (5+ commands) into scripts under `.buildkite/scripts/`.
+- **Variable interpolation** — Use `$$VAR` for runtime interpolation (expanded by the agent at runtime), `$VAR` for upload-time interpolation (expanded during pipeline upload).
+- **Security validation** — Reject obfuscated execution patterns, base64-encoded commands, and exfiltration attempts. Validate converted pipelines before deployment.
+- **Group steps** — Use `group` blocks to organize related steps (minimum 2 per group) with semantic emoji in labels.
+
+## Migration Planning
+
+For a full CI migration, plan across these areas:
+
+1. **Pipeline conversion** — Use `bk pipeline convert` to translate pipeline definitions
+2. **Agent infrastructure** — Set up clusters, queues, and agents
+3. **Secrets management** — Migrate secrets to Buildkite cluster secrets
+4. **Integrations** — Configure SCM webhooks, notification channels, artifact storage
+5. **Testing** — Run converted pipelines in parallel with the existing CI before cutover
+
+> For cluster and queue setup, see the **buildkite-platform-engineering** skill.
+> For setting up OIDC to replace static credentials, see the **buildkite-secure-delivery** skill.
+
+## Common Mistakes
+
+| Mistake | What happens | Fix |
+|---------|-------------|-----|
+| Vendor not auto-detected for gitlab/harness/bitrise | Error: "could not detect vendor from file path" | Pass `--vendor gitlab`, `--vendor harness`, or `--vendor bitrise` explicitly |
+| Large or complex pipelines timing out | Conversion fails with timeout error | Increase timeout: `--timeout 600`; split into smaller files if needed |
+| Accepting AI output without review | Converted pipeline has incorrect step ordering or missing dependencies | Review `depends_on` and `wait` steps against original CI job ordering |
+| Assuming sequential execution | Steps run in parallel and fail due to missing dependencies | Add `wait` steps or `depends_on` between dependent steps |
+| Unpinned plugin versions in converted pipelines | Builds break when plugins release breaking changes | Pin every plugin to a full semver version |
+| Using `$VAR` when runtime interpolation is needed | Variable expanded at upload time (empty) instead of runtime | Use `$$VAR` for variables that must resolve at runtime |
+
+## Further Reading
+
+- [bk CLI releases](https://github.com/buildkite/cli/releases) — download the bk binary
+- [Getting started with Buildkite Pipelines](https://buildkite.com/docs/pipelines)

--- a/skills/buildkite-pipelines/SKILL.md
+++ b/skills/buildkite-pipelines/SKILL.md
@@ -405,6 +405,8 @@ steps:
 - **`examples/basic-pipeline.yml`** — Minimal working pipeline (test, wait, deploy)
 - **`examples/optimized-pipeline.yml`** — Full-featured pipeline with caching, parallelism, annotations, retry, artifacts, and notifications
 
+> For migrating pipelines from other CI systems, see the **buildkite-migration** skill.
+
 ## Further Reading
 
 - [Defining pipeline steps](https://buildkite.com/docs/pipelines/configure/defining-steps)


### PR DESCRIPTION
## Overview
Introduce a new **buildkite-migration** skill to help users convert CI/CD pipelines from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines, and GitLab CI to Buildkite using the `bk pipeline convert` command.

## Changes

### New Skill Documentation
- **skills/buildkite-migration/SKILL.md** — Comprehensive guide covering:
  - Quick start with `bk pipeline convert`
  - Agent workflow for automated conversions
  - Installation and basic usage
  - Provider-specific concept mappings (GitHub Actions, Jenkins, CircleCI, Bitbucket, GitLab CI)
  - Pipeline best practices for migrated pipelines
  - Migration planning framework
  - Common mistakes and troubleshooting

### Documentation Updates
- **AGENTS.md** — Added buildkite-migration to Journey skills list
- **CONVENTIONS.md** — Defined skill ownership and reference patterns
- **README.md** — Added skill to installation instructions and skills index
- **llms.txt** — Added buildkite-migration topics

### Evaluation Datasets
- **evals/dataset.yaml** — Updated migration eval questions to use buildkite-migration as primary skill; added new GitHub Actions conversion eval
- **evals/trigger_dataset.yaml** — Added 7 should-trigger and 4 near-miss test cases for skill detection

### Cross-references
- **skills/buildkite-cli/SKILL.md** — Added reference to buildkite-migration for pipeline conversion
- **skills/buildkite-pipelines/SKILL.md** — Added reference to buildkite-migration for pipeline conversion guidance