### PR TITLE
Add dynamic pipeline deep-dive content to buildkite-pipelines skill

### DIFF
--- a/evals/dataset.yaml
+++ b/evals/dataset.yaml
@@ -1386,3 +1386,188 @@ evals:
       - "BUILDKITE_TRACING_BACKEND"
     expected_not_contains: []
     tags: ["observability", "datadog", "tracing", "performance"]
+
+  # ============================================================
+  # DYNAMIC PIPELINES DEEP-DIVE (added for PR #15 eval)
+  # ============================================================
+
+  - id: "dynpipe-001"
+    question: "My dynamic pipeline generator step passes green but no test steps appear after the generator step. The generator script itself passes (green tick). When I run the generator locally it prints valid YAML. What is going on?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "troubleshooting"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "pipefail"
+      - "set -euo pipefail"
+      - "exit code"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "troubleshooting", "silent-failure"]
+
+  - id: "dynpipe-002"
+    question: "I have a generator that produces a deploy step with env: DEPLOY_ENV: production but when deploy.sh runs, DEPLOY_ENV is empty. Why?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "troubleshooting"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "interpolat"
+      - "$$"
+      - "upload time"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "troubleshooting", "env-vars"]
+
+  - id: "dynpipe-003"
+    question: "We had a flaky network during a build. The generator step failed and someone clicked retry. Now the build has TWO copies of every test step and the deploy ran twice. How do I prevent this?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "troubleshooting"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "key"
+      - "DuplicateKeyError"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "troubleshooting", "duplicate-steps"]
+
+  - id: "dynpipe-004"
+    question: "I set concurrency: 1 and concurrency_group on my deploy steps in a dynamic generator, but two deploys to the same service ran concurrently. The concurrency_group uses $SERVICE in the value. What went wrong?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "troubleshooting"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "interpolat"
+      - "upload time"
+      - "generator"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "troubleshooting", "concurrency"]
+
+  - id: "dynpipe-005"
+    question: "I'm trying to set concurrency: 1 and concurrency_group on a group step to serialise all deploys but pipeline upload fails with 'concurrency is not a valid property on a group step'. How do I serialise deploys across a group?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "configuration"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "command step"
+      - "concurrency"
+      - "each"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "group-steps", "concurrency"]
+
+  - id: "dynpipe-006"
+    question: "I have a Tests group in my static pipeline.yml and my generator also produces a Tests group. I expected them to merge but I get two separate Tests groups in the UI. How do I make them merge?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "advanced"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "merg"
+      - "label"
+      - "inside"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "group-steps", "merging"]
+
+  - id: "dynpipe-007"
+    question: "Our integration tests OOM about 5% of the time on standard agents. When that happens I want them to automatically retry on our memory-large queue instead of the same machine. Built-in retry just retries on the same queue. What's the best approach?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "advanced"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: ["buildkite-agent-infrastructure"]
+    expected_contains:
+      - "pre-exit"
+      - "hook"
+      - "pipeline upload"
+      - "137"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "patterns", "retry", "cross-skill"]
+
+  - id: "dynpipe-008"
+    question: "I want a cleanup step that runs even if earlier steps failed. Like a finally block in a try/catch. Does Buildkite have this?"
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "advanced"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: ["buildkite-agent-runtime"]
+    expected_contains:
+      - "pre-exit"
+      - "hook"
+      - "allow_dependency_failure"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "patterns", "finalizer"]
+
+  - id: "dynpipe-009"
+    question: "I want to write a Buildkite pipeline that reads a webhook payload from build metadata, decides whether to act based on the payload, and dynamically generates steps. What's the recommended pattern for this?"
+    source: "synthetic"
+    source_ref: "dynamic-pipelines-examples-project"
+    difficulty: "advanced"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: ["buildkite-agent-runtime"]
+    expected_contains:
+      - "meta-data"
+      - "pipeline upload"
+      - "webhook"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "patterns", "handler-pattern", "cross-skill"]
+
+  - id: "dynpipe-010"
+    question: "I want to write a dynamic pipeline generator in Python using the Buildkite SDK instead of generating YAML strings in bash. How does that work?"
+    source: "synthetic"
+    source_ref: "dynamic-pipelines-examples-project"
+    difficulty: "configuration"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "SDK"
+      - "Pipeline"
+      - "pipeline upload"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "patterns", "sdk"]
+
+  - id: "dynpipe-011"
+    question: "I have a monorepo with 12 services. I want each changed service to get its own collapsible group in the build UI with build and test steps inside. The deploy should only start after all test groups pass. Write me a generator script."
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "configuration"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "group"
+      - "key"
+      - "depends_on"
+      - "git diff"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "group-steps", "monorepo"]
+
+  - id: "dynpipe-012"
+    question: "We're hitting the 500 jobs per upload limit. Our generator produces about 600 steps. What are my options? We have 30 services with build + test + integration + deploy step sets, plus parallelism: 4 on integration tests."
+    source: "synthetic"
+    source_ref: "pf-common-support-issue"
+    difficulty: "troubleshooting"
+    cluster: "dynamic-pipelines"
+    primary_skill: "buildkite-pipelines"
+    secondary_skills: []
+    expected_contains:
+      - "trigger"
+      - "split"
+      - "500"
+    expected_not_contains: []
+    tags: ["dynamic-pipelines", "troubleshooting", "limits"]

--- a/skills/buildkite-pipelines/SKILL.md
+++ b/skills/buildkite-pipelines/SKILL.md
@@ -228,20 +228,9 @@ steps:
       .buildkite/generate-pipeline.sh | buildkite-agent pipeline upload
 ```
 
-For debugging, upload the generated YAML as an artifact before piping to upload:
+**Always start generator scripts with `set -euo pipefail`.** Without `pipefail`, a failing `pipeline upload` returns the exit code of the last piped command, the build step reports success, and no generated steps appear — the most common dynamic pipeline failure mode.
 
-```yaml
-steps:
-  - label: ":pipeline: Generate"
-    command: |
-      .buildkite/generate-pipeline.sh | tee generated-pipeline.yml
-      buildkite-agent artifact upload generated-pipeline.yml
-      cat generated-pipeline.yml | buildkite-agent pipeline upload
-```
-
-Keep dynamically generated pipelines under **~500 steps** for optimal UI and processing performance. For larger monorepos, use orchestrator pipelines with trigger steps to spawn child pipelines.
-
-Example generator script that runs tests only for changed services:
+Example generator that runs tests only for changed services:
 
 ```bash
 #!/bin/bash
@@ -256,12 +245,19 @@ for dir in services/*/; do
     cat <<YAML
   - label: ":test_tube: $svc"
     command: "cd services/$svc && make test"
+    key: "test-$svc"
 YAML
   fi
 done
 ```
 
-For advanced generator patterns (Python, monorepo, multi-stage), see `references/advanced-patterns.md`.
+Set `key:` on every generated step. It enables `depends_on`, makes retries idempotent (`DuplicateKeyError` blocks silent duplication if the upload step re-runs), and gives stable identifiers across builds. Validate locally with `buildkite-agent pipeline upload --dry-run` before pushing.
+
+Keep uploads under **500 steps per call** and **4,000 jobs per build** (platform defaults, raisable via support). For larger monorepos, use trigger steps to fan out across separate builds.
+
+For type-checked, unit-testable generators, the [Buildkite SDK](https://github.com/buildkite/buildkite-sdk) supports JavaScript/TypeScript, Python, Go, and Ruby. Wrap related steps in group steps once a generator produces more than ~10 steps — adding any group enables DAG mode for the build, and `concurrency` attributes are rejected on groups (see `references/group-steps.md`).
+
+A generator step can also read runtime state (meta-data, artifacts, git diff) and upload the next phase of the pipeline — the handler pattern used by multi-stage builds. For this, fan-out/fan-in, and finalizer / always-run steps via `pre-exit` hooks, see `references/dynamic-pipeline-patterns.md`. For failure modes, see `references/dynamic-pipeline-troubleshooting.md`. For advanced generator patterns (Python, monorepo, multi-stage), see `references/advanced-patterns.md`.
 
 ## Conditional Execution
 
@@ -446,6 +442,9 @@ For full concurrency configuration options, see [Controlling Concurrency](https:
 - **`references/step-types-reference.md`** — Detailed attribute tables for all step types
 - **`references/advanced-patterns.md`** — Dynamic pipeline generators, matrix adjustments, monorepo patterns, multi-stage pipelines
 - **`references/retry-and-error-codes.md`** — Comprehensive exit code table, retry strategies by failure type
+- **`references/group-steps.md`** — Group step attributes, DAG mode, merging across uploads, no-nesting workaround, job-limit impact
+- **`references/dynamic-pipeline-troubleshooting.md`** — Silent upload failures, quota limits, env var interpolation, duplicate-on-retry, retry storms
+- **`references/dynamic-pipeline-patterns.md`** — Fan-out/fan-in, SDK generation, the handler pattern, finalizer steps, trigger-based fan-out
 
 ### Examples
 - **`examples/basic-pipeline.yml`** — Minimal working pipeline (test, wait, deploy)

--- a/skills/buildkite-pipelines/SKILL.md
+++ b/skills/buildkite-pipelines/SKILL.md
@@ -228,6 +228,37 @@ steps:
       .buildkite/generate-pipeline.sh | buildkite-agent pipeline upload
 ```
 
+### When to use what
+
+Pipelines exist on a spectrum. Pick the simplest option that does the job:
+
+| Situation | Approach |
+|-----------|----------|
+| Same steps every build, branch-level filtering at most | Static YAML |
+| Skip steps when specific files haven't changed | `if_changed` |
+| Monorepo with separate pipelines per service | `monorepo-diff` plugin |
+| Combine `if` and `if_changed` with OR logic | Dynamic generation |
+| Apply consistent retry / timeout / env config across many pipelines | Dynamic (shared config) |
+| Calculate test shards, matrix combos, `parallelism × matrix` at runtime | Dynamic (often SDK) |
+| Monorepo with transitive dependencies between services | Dynamic (custom dep graph) |
+| Recover from infra failures (OOM → bigger agent) | Dynamic (`pre-exit` hook) |
+| Steps depend on output from previous steps (multi-stage) | Dynamic, often `--replace` or chained uploads |
+| Cleanup / teardown step that must run regardless of earlier failures | Dynamic (`pre-exit` uploads a finalizer) |
+| Fallback step only when the primary step fails | Dynamic (`pre-exit` checking exit status) |
+| Pipeline YAML has outgrown what the team can maintain | Dynamic (SDK in Python / TS / Go / Ruby) |
+
+### Don't reach for dynamic pipelines for the wrong job
+
+Dynamic generation is the right tool when the *steps themselves* need to change. For passing data between steps, simpler primitives exist:
+
+- **`buildkite-agent meta-data set/get`** — small key-value pairs any later step in the same build can read (a version string, a commit SHA, a feature flag).
+- **Artifacts** — files passed between steps (`buildkite-agent artifact upload/download`).
+- **Trigger step `env:`** — env vars passed to a build in a different pipeline.
+
+If only data needs to move, metadata or artifacts is simpler and safer. See the **buildkite-agent-runtime** skill.
+
+### Bootstrap script
+
 **Always start generator scripts with `set -euo pipefail`.** Without `pipefail`, a failing `pipeline upload` returns the exit code of the last piped command, the build step reports success, and no generated steps appear — the most common dynamic pipeline failure mode.
 
 Example generator that runs tests only for changed services:

--- a/skills/buildkite-pipelines/references/dynamic-pipeline-patterns.md
+++ b/skills/buildkite-pipelines/references/dynamic-pipeline-patterns.md
@@ -6,6 +6,17 @@ For monorepo change detection, basic `if_changed`, and matrix builds, see `refer
 For group step behaviour in dynamic pipelines, see `references/group-steps.md`.
 For common failure modes, see `references/dynamic-pipeline-troubleshooting.md`.
 
+## Contents
+
+1. [Fan-out and fan-in with depends_on](#fan-out-and-fan-in-with-depends_on)
+2. [SDK-based pipeline generation](#sdk-based-pipeline-generation)
+3. [The handler pattern: read state, decide, upload](#the-handler-pattern-read-state-decide-upload)
+4. [Finalizer and always-run steps](#finalizer-and-always-run-steps)
+5. [Branch-based routing](#branch-based-routing)
+6. [Serial gate chains](#serial-gate-chains)
+7. [Trigger-based fan-out for large workloads](#trigger-based-fan-out-for-large-workloads)
+8. [Centralised pipeline generation](#centralised-pipeline-generation)
+
 ## Fan-out and fan-in with depends_on
 
 Dynamic generation plus `depends_on` produces fan-out/fan-in graphs that do not fit in a single `parallelism:` step or a static matrix. The pattern: emit one step per work item with a stable `key:`, then emit a single downstream step that depends on every upstream key.

--- a/skills/buildkite-pipelines/references/dynamic-pipeline-patterns.md
+++ b/skills/buildkite-pipelines/references/dynamic-pipeline-patterns.md
@@ -1,0 +1,311 @@
+# Dynamic Pipeline Patterns
+
+Patterns for generating pipeline steps at runtime that go beyond the basic monorepo and `if_changed` patterns covered in `references/advanced-patterns.md`. This reference focuses on fan-out/fan-in, SDK-based generation, runtime decision-making, and finalizer patterns.
+
+For monorepo change detection, basic `if_changed`, and matrix builds, see `references/advanced-patterns.md`.
+For group step behaviour in dynamic pipelines, see `references/group-steps.md`.
+For common failure modes, see `references/dynamic-pipeline-troubleshooting.md`.
+
+## Fan-out and fan-in with depends_on
+
+Dynamic generation plus `depends_on` produces fan-out/fan-in graphs that do not fit in a single `parallelism:` step or a static matrix. The pattern: emit one step per work item with a stable `key:`, then emit a single downstream step that depends on every upstream key.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+SERVICES="api web worker payments notifications"
+
+echo "steps:"
+
+# Fan out: one test step per service
+for svc in $SERVICES; do
+  cat <<YAML
+  - label: ":test_tube: Test ${svc}"
+    command: "make test -C services/${svc}"
+    key: "test-${svc}"
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+YAML
+done
+
+# Fan in: single step that waits for every upstream key
+FAN_IN_DEPS=$(for svc in $SERVICES; do echo "      - \"test-${svc}\""; done)
+cat <<YAML
+  - label: ":white_check_mark: All services passed"
+    command: "echo 'all green'"
+    key: "tests-complete"
+    depends_on:
+${FAN_IN_DEPS}
+YAML
+```
+
+Use this instead of `wait` when some downstream work can start before every upstream finishes. `wait` blocks all prior steps; `depends_on` expresses exact dependencies, letting unrelated steps run in parallel. Combine with `allow_dependency_failure: true` on the fan-in step to report partial success rather than block.
+
+## SDK-based pipeline generation
+
+Any language that emits valid YAML or JSON on stdout works as a generator. Shell and Python are the most common. For type checking, IDE support, and unit-testable generators, use the [Buildkite SDK](https://github.com/buildkite/buildkite-sdk) — available for JavaScript/TypeScript, Python, Go, and Ruby.
+
+```python
+#!/usr/bin/env python3
+"""Generate test steps programmatically with the Buildkite SDK."""
+from buildkite_sdk import Pipeline, CommandStep
+
+pipeline = Pipeline()
+
+services = ["api", "web", "worker"]
+retry_policy = {
+    "automatic": [
+        {"exit_status": -1, "limit": 2},
+        {"exit_status": 143, "limit": 1},
+    ]
+}
+
+# Fan out
+for svc in services:
+    step = CommandStep()
+    step.label = f":test_tube: Test {svc}"
+    step.command = [f"make test -C services/{svc}"]
+    step.key = f"test-{svc}"
+    step.retry = retry_policy
+    pipeline.add_step(step)
+
+# Fan in
+fan_in = CommandStep()
+fan_in.label = ":white_check_mark: All services passed"
+fan_in.command = ["echo 'all green'"]
+fan_in.key = "tests-complete"
+fan_in.depends_on = [f"test-{svc}" for svc in services]
+pipeline.add_step(fan_in)
+
+print(pipeline.to_yaml())
+```
+
+Use in the pipeline:
+
+```yaml
+steps:
+  - label: ":pipeline: Generate"
+    command: "python .buildkite/generate.py | buildkite-agent pipeline upload"
+```
+
+Reach for the SDK when generators need:
+
+- Dependency resolution across many steps (computing `depends_on` from a graph).
+- Shared retry / timeout / queue policies applied consistently across every step.
+- Conditional logic that becomes hard to read in bash heredocs.
+- Unit tests for the generator itself.
+
+Plain shell is still the right choice when the generator is short and produces a small number of steps.
+
+## The handler pattern: read state, decide, upload
+
+The core dynamic pipeline archetype: a step reads runtime state (meta-data, artifacts, API responses, git diff), decides what to do, and uploads the next phase of the pipeline. This pattern underpins multi-stage pipelines that adapt mid-flight.
+
+```bash
+#!/bin/bash
+# .buildkite/scripts/phase2-deploy.sh
+# Runs after an earlier "build" step uploaded a manifest artifact.
+set -euo pipefail
+
+# Read runtime state: what did the build produce?
+buildkite-agent artifact download "build-manifest.json" .
+SERVICES=$(jq -r '.services[]' build-manifest.json)
+
+# Read runtime state: did a previous step flag a hotfix deploy?
+DEPLOY_MODE=$(buildkite-agent meta-data get "deploy-mode" --default "standard")
+
+# Decide and generate
+STEPS="steps:\n"
+for svc in $SERVICES; do
+  if [[ "$DEPLOY_MODE" == "hotfix" ]]; then
+    # Hotfix: skip staging, deploy direct to production
+    STEPS+="  - label: \":fire: Hotfix deploy ${svc}\"\n"
+    STEPS+="    command: \"make deploy-production SERVICE=${svc}\"\n"
+    STEPS+="    key: \"deploy-${svc}\"\n"
+    STEPS+="    concurrency: 1\n"
+    STEPS+="    concurrency_group: \"deploy/${svc}/production\"\n"
+  else
+    STEPS+="  - label: \":rocket: Deploy ${svc} to staging\"\n"
+    STEPS+="    command: \"make deploy-staging SERVICE=${svc}\"\n"
+    STEPS+="    key: \"deploy-staging-${svc}\"\n"
+    STEPS+="    concurrency: 1\n"
+    STEPS+="    concurrency_group: \"deploy/${svc}/staging\"\n"
+  fi
+done
+
+echo -e "$STEPS" | buildkite-agent pipeline upload
+```
+
+The inputs available to a handler step:
+
+| Source | Use for | Access via |
+|--------|---------|-----------|
+| Build meta-data | Small key/value decisions set by earlier steps | `buildkite-agent meta-data get KEY` |
+| Artifacts | Files produced by earlier steps (manifests, test reports) | `buildkite-agent artifact download 'path'` |
+| Environment variables | Build-level context (`BUILDKITE_BRANCH`, `BUILDKITE_MESSAGE`, …) | Shell `$VAR` |
+| Git state | Changed files, tags, commit metadata | `git diff`, `git log`, `git describe` |
+| External APIs | Feature flags, deployment approvals, issue tracker state | `curl`, language HTTP clients |
+
+See the **buildkite-agent-runtime** skill for the full `meta-data` and `artifact` subcommand reference.
+
+### Replace pattern for clean build pages
+
+A variant of the handler pattern uses `--replace` to swap the bootstrap step with the real pipeline before the UI settles:
+
+```yaml
+# .buildkite/pipeline.yml (gets replaced)
+steps:
+  - label: ":pipeline: Setup"
+    command: ".buildkite/generate.sh | buildkite-agent pipeline upload --replace"
+```
+
+`--replace` removes all pending steps before inserting the new ones. Jobs already running are not affected. The build page shows only the generated pipeline, not the bootstrap step.
+
+**Caution.** If the generator fails after `--replace` removes the existing steps but before new steps are uploaded, the build has no steps. Always pair with `set -euo pipefail` and consider `--dry-run` validation before calling the real upload.
+
+Do not use `--replace` when multiple steps each upload their own portion of the pipeline — a retry of one step would wipe steps uploaded by others.
+
+## Finalizer and always-run steps
+
+Built-in pipeline primitives do not have an "always run, regardless of earlier failures" step type. The `pre-exit` agent hook fills that gap: it runs after every step, including failed ones, and can call `pipeline upload` to inject a finalizer step.
+
+### Cleanup that runs even after failure
+
+```bash
+# .buildkite/hooks/pre-exit
+#!/bin/bash
+
+# Only inject the cleanup once per build
+if [[ "${BUILDKITE_STEP_KEY:-}" == "deploy" ]]; then
+  buildkite-agent pipeline upload <<'YAML'
+steps:
+  - label: ":broom: Cleanup deploy artifacts"
+    command: ".buildkite/scripts/cleanup.sh"
+    key: "cleanup"
+    allow_dependency_failure: true
+YAML
+fi
+```
+
+`allow_dependency_failure: true` on the cleanup step lets it run even when the deploy failed. Without it, a failed upstream step would block the cleanup.
+
+### Fallback step when the primary step fails
+
+```bash
+# .buildkite/hooks/pre-exit
+#!/bin/bash
+
+if [[ "$BUILDKITE_COMMAND_EXIT_STATUS" -ne 0 ]] && \
+   [[ "${BUILDKITE_STEP_KEY:-}" == "primary-deploy" ]]; then
+  buildkite-agent pipeline upload <<YAML
+steps:
+  - label: ":rewind: Rollback ${BUILDKITE_LABEL}"
+    command: "make rollback"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+YAML
+fi
+```
+
+The unquoted heredoc (`<<YAML`) expands `${BUILDKITE_LABEL}` at upload time — intentional here because the label identifies the failed step.
+
+### Retry on different infrastructure (OOM, spot preemption)
+
+Built-in `retry: automatic` retries on the **same queue**. For failures caused by resource constraints (OOM, disk exhaustion, spot preemption), the same queue does not help. Use a `pre-exit` hook to detect the failure and upload a new step targeting a bigger queue:
+
+```bash
+# .buildkite/hooks/pre-exit
+#!/bin/bash
+
+if [[ "$BUILDKITE_COMMAND_EXIT_STATUS" == "137" ]]; then
+  echo "OOM detected. Retrying on memory-optimised agent."
+  buildkite-agent pipeline upload <<YAML
+steps:
+  - label: ":repeat: Retry ${BUILDKITE_LABEL} (memory-optimised)"
+    command: "${BUILDKITE_COMMAND}"
+    agents:
+      queue: "memory-optimised"
+    retry:
+      automatic:
+        - exit_status: 137
+          limit: 1
+YAML
+fi
+```
+
+Two important notes:
+
+- **Unquoted heredoc (`<<YAML`)** is correct here — `${BUILDKITE_LABEL}` and `${BUILDKITE_COMMAND}` need to expand at upload time.
+- **`limit: 1`** on the uploaded retry step prevents infinite retry loops when the bigger agent also runs out of memory.
+
+This pattern works for any infrastructure-class failure where a different queue would help. For exit code reference, see `references/retry-and-error-codes.md`. For agent hook configuration, see the **buildkite-agent-infrastructure** skill.
+
+## Trigger-based fan-out for large workloads
+
+Workloads that exceed a single build's limits can fan out across separate builds using trigger steps:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+CHANGED_SERVICES=$(git diff --name-only HEAD~1 | grep '^services/' | cut -d/ -f2 | sort -u)
+
+STEPS="steps:\n"
+for svc in $CHANGED_SERVICES; do
+  STEPS+="  - trigger: \"service-${svc}-tests\"\n"
+  STEPS+="    label: \":rocket: Test ${svc}\"\n"
+  STEPS+="    build:\n"
+  STEPS+="      branch: \"${BUILDKITE_BRANCH}\"\n"
+  STEPS+="      commit: \"${BUILDKITE_COMMIT}\"\n"
+  STEPS+="      message: \"Tests for ${svc} (triggered by ${BUILDKITE_BUILD_NUMBER})\"\n"
+done
+
+echo -e "$STEPS" | buildkite-agent pipeline upload
+```
+
+Each triggered build has its own upload and job limits. A monorepo with 20 services × 100 steps each would need 2,000 jobs in one build — with triggers, the parent build has only 20 trigger steps and each service build handles its own 100 steps independently.
+
+## Centralised pipeline generation
+
+Large organisations often centralise generator logic so every team gets consistent pipeline patterns:
+
+```
+infra-repo/
+├── pipeline-generator/
+│   ├── generate.py          # Main generator
+│   ├── templates/
+│   │   ├── standard.yml     # Standard test + deploy
+│   │   ├── monorepo.yml     # Monorepo with change detection
+│   │   └── ml-training.yml  # ML training pipeline
+│   └── config/
+│       └── defaults.yml     # Org-wide defaults (retry, queues, timeouts)
+```
+
+Each service repo's `.buildkite/pipeline.yml` calls the centralised generator:
+
+```yaml
+steps:
+  - label: ":pipeline: Generate"
+    command: |
+      git clone git@github.com:example-org/infra-repo.git /tmp/infra
+      python /tmp/infra/pipeline-generator/generate.py \
+        --config .buildkite/service-config.yml \
+        | buildkite-agent pipeline upload
+```
+
+The centralised generator applies org-wide defaults (retry policies, queue targeting, timeout limits) while letting each service override specifics. This pattern prevents every team from independently rediscovering the same pitfalls.
+
+## Further Reading
+
+- [Dynamic pipelines overview](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines.md)
+- [`pipeline upload` CLI reference](https://buildkite.com/docs/agent/v3/cli-pipeline.md)
+- [Buildkite SDK](https://github.com/buildkite/buildkite-sdk)
+- [Agent hooks](https://buildkite.com/docs/agent/v3/hooks.md)
+- [Build meta-data](https://buildkite.com/docs/pipelines/configure/build-meta-data.md)

--- a/skills/buildkite-pipelines/references/dynamic-pipeline-patterns.md
+++ b/skills/buildkite-pipelines/references/dynamic-pipeline-patterns.md
@@ -247,6 +247,132 @@ Two important notes:
 
 This pattern works for any infrastructure-class failure where a different queue would help. For exit code reference, see `references/retry-and-error-codes.md`. For agent hook configuration, see the **buildkite-agent-infrastructure** skill.
 
+## Branch-based routing
+
+Generate different pipelines per branch. Common shape for repos where `main`, `release/*`, and feature branches have very different needs:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+BRANCH="$BUILDKITE_BRANCH"
+
+case "$BRANCH" in
+  main)
+    cat <<'YAML' | buildkite-agent pipeline upload
+steps:
+  - group: ":test_tube: Tests"
+    key: "tests"
+    steps:
+      - label: ":rspec: Unit"
+        command: "make test-unit"
+        key: "unit"
+      - label: ":earth_americas: Integration"
+        command: "make test-integration"
+        key: "integration"
+  - wait
+  - group: ":rocket: Deploy"
+    key: "deploy"
+    steps:
+      - label: ":rocket: Deploy staging"
+        command: "make deploy-staging"
+        key: "deploy-staging"
+      - wait
+      - label: ":rocket: Deploy production"
+        command: "make deploy-production"
+        key: "deploy-prod"
+        concurrency: 1
+        concurrency_group: "deploy/production"
+YAML
+    ;;
+  release/*)
+    cat <<'YAML' | buildkite-agent pipeline upload
+steps:
+  - label: ":test_tube: Full test suite"
+    command: "make test-all"
+    key: "full-tests"
+    parallelism: 10
+  - wait
+  - block: ":shipit: Approve release"
+    key: "approve"
+  - wait
+  - label: ":rocket: Deploy production"
+    command: "make deploy-production"
+    depends_on: "approve"
+    concurrency: 1
+    concurrency_group: "deploy/production"
+YAML
+    ;;
+  *)
+    # PR and feature branches: just lint and test
+    cat <<'YAML' | buildkite-agent pipeline upload
+steps:
+  - label: ":lint-roller: Lint"
+    command: "make lint"
+    key: "lint"
+  - label: ":rspec: Tests"
+    command: "make test"
+    key: "tests"
+YAML
+    ;;
+esac
+```
+
+Use `<<'YAML'` (quoted heredoc) to prevent shell expansion of `$` characters in the YAML. Use `<<YAML` (unquoted) only when shell variable expansion in the template is intentional.
+
+This pattern is the upgrade path when `if: build.branch == "main"` filters on individual steps become unreadable or when per-branch step counts diverge enough that one static pipeline can't express them cleanly.
+
+## Serial gate chains
+
+Chain multiple phases, where each phase generates the next based on its output. Useful when later steps genuinely depend on what earlier steps produced — not just their success.
+
+Phase 1 builds and uploads a manifest:
+
+```yaml
+# .buildkite/pipeline.yml — phase 1
+steps:
+  - label: ":hammer: Build"
+    command: "make build && buildkite-agent artifact upload 'dist/*'"
+    key: "build"
+  - wait
+  - label: ":test_tube: Generate test plan"
+    command: ".buildkite/generate-tests.sh | buildkite-agent pipeline upload"
+    key: "gen-tests"
+```
+
+Phase 2 reads the manifest and emits per-component test steps plus a deploy gate:
+
+```bash
+#!/bin/bash
+# .buildkite/generate-tests.sh — phase 2
+set -euo pipefail
+
+# Download the build manifest to see what was built
+buildkite-agent artifact download "dist/manifest.json" .
+COMPONENTS=$(jq -r '.components[]' dist/manifest.json)
+
+STEPS="steps:\n"
+for component in $COMPONENTS; do
+  STEPS+="  - label: \":test_tube: Test ${component}\"\n"
+  STEPS+="    command: \"make test-${component}\"\n"
+  STEPS+="    key: \"test-${component}\"\n"
+done
+
+# Gate for deployment
+STEPS+="  - wait\n"
+STEPS+="  - block: \":shipit: Deploy?\"\n"
+STEPS+="    key: \"deploy-gate\"\n"
+STEPS+="  - wait\n"
+STEPS+="  - label: \":rocket: Deploy\"\n"
+STEPS+="    command: \"make deploy\"\n"
+STEPS+="    concurrency: 1\n"
+STEPS+="    concurrency_group: \"deploy/production\"\n"
+
+echo -e "$STEPS" | buildkite-agent pipeline upload
+```
+
+Each phase has full access to what prior phases produced (artifacts, meta-data, API state), so the pipeline shape can adapt mid-flight. Pair with `--replace` on the bootstrap step only when a single uploader owns the entire downstream pipeline.
+
 ## Trigger-based fan-out for large workloads
 
 Workloads that exceed a single build's limits can fan out across separate builds using trigger steps:
@@ -276,7 +402,7 @@ Each triggered build has its own upload and job limits. A monorepo with 20 servi
 
 Large organisations often centralise generator logic so every team gets consistent pipeline patterns:
 
-```
+```text
 infra-repo/
 ├── pipeline-generator/
 │   ├── generate.py          # Main generator

--- a/skills/buildkite-pipelines/references/dynamic-pipeline-troubleshooting.md
+++ b/skills/buildkite-pipelines/references/dynamic-pipeline-troubleshooting.md
@@ -2,6 +2,22 @@
 
 Failure modes specific to pipelines that generate steps at runtime via `buildkite-agent pipeline upload`. Ordered by frequency — silent upload failures and quota issues come first.
 
+## Diagnose in this order
+
+Most production failures fall into a small set of patterns. Work down this list before deeper investigation:
+
+1. **Build green, no generated steps appear** — generator script missing `set -euo pipefail`. The upload failed; bash reported the script's exit code, not the upload's. Fix: add `set -euo pipefail`.
+2. **`The number of jobs in this upload exceeds your organization limit of 500`** — split the output into multiple smaller uploads, or use trigger steps to fan across separate builds. Account for `parallelism` (multiplies jobs).
+3. **`pipeline parsing of "(stdin)" failed: <error>`** — invalid YAML. Run with `--dry-run` locally; capture the generator output to a file and run it through a YAML linter.
+4. **Generated steps in unexpected order** — `pipeline upload` inserts immediately after the calling step. Multiple uploads from the same step appear in reverse upload order. Use `depends_on` for explicit ordering.
+5. **Env vars empty in generated steps** — interpolated at upload time. Use `$$VAR` to defer.
+6. **Duplicate steps after retry of the upload step** — the generator re-ran. Set `key:` on every step (uploads with duplicate keys fail loudly with `DuplicateKeyError`) or use `--replace` if the step is responsible for the entire downstream pipeline.
+7. **Concurrency limits not working** — concurrency group name was interpolated at upload time and resolved to something unexpected. Emit literal strings from the generator.
+8. **Notifications not firing on generated steps** — step-level notifications are not inherited from the initial pipeline. Add `notify:` to the generated step itself.
+9. **Build hits 4,000 jobs-per-build limit** — `(steps × parallelism) + (retries × steps)`. Split with trigger steps or reduce `parallelism` using Test Engine's timing-based test splitting.
+
+Each item below expands one of the above with root cause, fix, and debugging guidance.
+
 ## Common Mistakes
 
 | Mistake | What happens | Fix |
@@ -304,6 +320,14 @@ fi
 
 This consumes an agent slot to evaluate the condition but gives full control over the logic. The standard upgrade path when teams outgrow `if_changed`.
 
+## Matrix and parallelism on the same step
+
+**Symptom.** A step uses `matrix` and `parallelism` together. The pipeline is rejected, or matrix values silently fail to accept nested objects.
+
+**Why.** Buildkite's built-in `matrix` does not combine with `parallelism` on the same step, and matrix values must be flat strings (no nested objects).
+
+**Fix.** Use a generator (often via the SDK) to compute combinations and emit individual steps. See `references/dynamic-pipeline-patterns.md` → "SDK-based pipeline generation" for the worked example.
+
 ## Retry storms during infrastructure incidents
 
 **Symptom.** During an infrastructure issue (spot preemption, network outage, dependent service down), many jobs fail at once and all retry simultaneously, multiplying load on an already-broken fleet.
@@ -320,6 +344,44 @@ This consumes an agent slot to evaluate the condition but gives full control ove
   - `255` timeout / SSH failure
 - **Use a different queue for retries** on infra failures instead of retrying on the same broken fleet. See `references/dynamic-pipeline-patterns.md` for the `pre-exit` hook pattern.
 - **Watch the per-build retry budget**: `(steps × max_retries)` counts toward the 4,000 jobs-per-build limit.
+
+## Security
+
+Any running job can call `pipeline upload`. If a forked PR modifies `.buildkite/`, those scripts run on the pipeline's agents. Treat dynamic pipelines as a privilege-escalation surface.
+
+**Disable fork builds for sensitive pipelines.** Buildkite repository setting. The safest option when the pipeline has access to production secrets.
+
+**For pipelines that need to accept fork PRs, gate them behind a manual approval.** Either with a static `if`:
+
+```yaml
+- block: ":lock: Approve fork build"
+  if: build.pull_request_repo != "" && build.pull_request_repo != build.repository
+  prompt: "This build is from a fork. Review the code before allowing it to run."
+```
+
+Or with a generator (when allowlist logic is needed):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+if [ "${BUILDKITE_PULL_REQUEST_REPO}" != "" ] && \
+   [ "${BUILDKITE_PULL_REQUEST_REPO}" != "${BUILDKITE_REPO}" ]; then
+  buildkite-agent pipeline upload <<'YAML'
+steps:
+  - block: ":lock: Approve fork build"
+    prompt: "This build is from a fork. Review before allowing on our agents."
+YAML
+fi
+
+buildkite-agent pipeline upload  # main pipeline; appears after the block
+```
+
+**Pass `--reject-secrets` to `pipeline upload`** to reject YAML containing values matching secret-like names (`*_TOKEN`, `*_SECRET`, `*_KEY`). Opt-in, disabled by default.
+
+**Kubernetes setups:** `pipeline upload` can be used to inject steps that run with higher-privilege service accounts. Audit which steps can call `pipeline upload` and what service accounts they run under.
+
+For the durable answer — cryptographic verification that uploaded YAML matches what was signed — see pipeline signing below and the **buildkite-secure-delivery** skill.
 
 ## Pipeline signing with dynamic uploads
 

--- a/skills/buildkite-pipelines/references/dynamic-pipeline-troubleshooting.md
+++ b/skills/buildkite-pipelines/references/dynamic-pipeline-troubleshooting.md
@@ -2,6 +2,26 @@
 
 Failure modes specific to pipelines that generate steps at runtime via `buildkite-agent pipeline upload`. Ordered by frequency — silent upload failures and quota issues come first.
 
+## Contents
+
+1. [Diagnose in this order](#diagnose-in-this-order)
+2. [Common Mistakes](#common-mistakes)
+3. [Silent upload failures](#silent-upload-failures)
+4. [Debugging strategies](#debugging-strategies)
+5. [Upload quota exceeded](#upload-quota-exceeded)
+6. [Job count surprises](#job-count-surprises)
+7. [Upload performance at scale](#upload-performance-at-scale)
+8. [Step insertion order](#step-insertion-order)
+9. [Environment variable interpolation](#environment-variable-interpolation)
+10. [Duplicate steps after retry of an upload step](#duplicate-steps-after-retry-of-an-upload-step)
+11. [Concurrency in dynamically generated steps](#concurrency-in-dynamically-generated-steps)
+12. [Notifications on dynamically generated steps](#notifications-on-dynamically-generated-steps)
+13. [Combining if and if_changed](#combining-if-and-if_changed)
+14. [Matrix and parallelism on the same step](#matrix-and-parallelism-on-the-same-step)
+15. [Retry storms during infrastructure incidents](#retry-storms-during-infrastructure-incidents)
+16. [Security](#security)
+17. [Pipeline signing with dynamic uploads](#pipeline-signing-with-dynamic-uploads)
+
 ## Diagnose in this order
 
 Most production failures fall into a small set of patterns. Work down this list before deeper investigation:

--- a/skills/buildkite-pipelines/references/dynamic-pipeline-troubleshooting.md
+++ b/skills/buildkite-pipelines/references/dynamic-pipeline-troubleshooting.md
@@ -1,0 +1,338 @@
+# Dynamic Pipeline Troubleshooting
+
+Failure modes specific to pipelines that generate steps at runtime via `buildkite-agent pipeline upload`. Ordered by frequency — silent upload failures and quota issues come first.
+
+## Common Mistakes
+
+| Mistake | What happens | Fix |
+|---------|-------------|-----|
+| Generator script missing `set -euo pipefail` | Upload fails but build step reports success; no steps appear | Start every generator script with `set -euo pipefail` |
+| Relying on upload order for step ordering | Multiple uploads from one step appear in reverse order; generated steps surface in unexpected positions | Declare execution order with `depends_on` between step keys |
+| Referencing `$VAR` for a step's own `env:` value | Variable is empty when step runs — interpolation happens at upload time | Escape with `$$VAR` to defer evaluation to step runtime |
+| Retrying the upload step without `key:` | Steps upload twice; build runs every step in duplicate | Set `key:` on every generated step — `DuplicateKeyError` then blocks re-upload |
+| Using `concurrency_group: "deploy/$SERVICE"` in generator | `$SERVICE` interpolates from generator environment, not per-step; steps share or leak concurrency groups | Compute the literal string in the generator before emitting YAML |
+| Assuming step-level `notify` inherits into uploaded steps | Notifications silently do not fire on generated steps | Emit `notify:` on each generated step that needs it |
+| Using `exit_status: "*"` with high retry limit | An outage multiplies jobs: 200 steps × 2 retries = 400 retry jobs hitting the broken fleet | Target specific exit codes and cap wildcard retries at `limit: 1` |
+| Pipeline processing timeout on huge uploads | HTTP 529 from agent, then retry or rejection | Split into multiple smaller uploads inside the generator |
+
+## Silent upload failures
+
+**Symptom.** The generator step completes green. No generated steps appear in the build.
+
+**Why.** The generator script does not set `set -euo pipefail`. When `pipeline upload` fails (rejected YAML, quota exceeded, network error, processing timeout), bash without `pipefail` reports the exit code of the **last** command in a pipe. So `script | pipeline upload` returns the script's exit code (often 0) and the build step succeeds.
+
+The agent is not silent: the Buildkite API returns HTTP 422 (rejected), 500 (failed), or 529 (timeout/retry) on upload failures. Internally, uploads move through PENDING → PROCESSING → APPLIED (or REJECTED / FAILED). The failure is silent only because the script swallowed it.
+
+**Fix.**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+.buildkite/generate-pipeline.sh | buildkite-agent pipeline upload
+```
+
+`-e` exits on any non-zero return. `pipefail` makes a failure anywhere in a pipe (not just the last command) fail the whole pipe. Together they ensure the build step fails when the upload fails.
+
+## Debugging strategies
+
+Static pipelines live in the repo and are easy to read. Dynamic pipelines only exist at build time, so debugging needs different tooling. Three layers, in order of when they help:
+
+### Local validation with --dry-run
+
+Parses and interpolates the YAML, prints the result, does not upload:
+
+```bash
+.buildkite/generate-pipeline.sh | buildkite-agent pipeline upload --dry-run
+```
+
+Invalid YAML exits with `buildkite-agent: fatal: pipeline parsing of "(stdin)" failed: <error>`. The error does not always pinpoint the line — for complex generators, redirect the output to a file and run a YAML linter against it, or use `bk pipeline validate` (see the **buildkite-cli** skill).
+
+### Production validation with artifact capture
+
+Save the generated YAML as a build artifact every build, validate it, then upload:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+.buildkite/generate-pipeline.sh > /tmp/generated-pipeline.yml
+buildkite-agent pipeline upload --dry-run < /tmp/generated-pipeline.yml > /dev/null
+buildkite-agent artifact upload /tmp/generated-pipeline.yml
+buildkite-agent pipeline upload /tmp/generated-pipeline.yml
+```
+
+`set -e` ensures the build fails if `--dry-run` rejects the YAML. The artifact persists on the build page for later inspection via `buildkite-agent artifact download`.
+
+### Annotations summarising decisions
+
+Record what the generator decided as a build annotation and metadata so later debugging does not require re-running the generator:
+
+```bash
+buildkite-agent meta-data set "generated-services" "$CHANGED"
+buildkite-agent annotate "Generated steps for: ${CHANGED}" \
+  --style "info" --context "generator"
+```
+
+See the **buildkite-agent-runtime** skill for full `annotate` and `meta-data` reference.
+
+## Upload quota exceeded
+
+**Symptom.** Build fails with `The number of jobs in this upload exceeds your organization limit of 500`. Steps already in the build are unaffected; nothing from the rejected upload is added.
+
+**Defaults (raisable via Buildkite support):**
+
+| Limit | Default | Note |
+|-------|---------|------|
+| Jobs per `pipeline upload` | 500 | A step with `parallelism: 10` counts as 10 |
+| Pipeline uploads per build | 500 | Each call to `pipeline upload` |
+| Jobs per build | 4,000 | Each retry attempt is a separate job |
+
+Visible in **Organisation Settings > Quotas > Service Quotas**.
+
+**Three options to fix:**
+
+1. **Split into multiple smaller uploads.** Loop in the generator and call `pipeline upload` per service, shard, or batch. Two uploads of 300 steps process more reliably than one upload of 600.
+2. **Use trigger steps to fan out.** A monorepo with 20 services × 30 steps each = 600 jobs in one build (rejected). With trigger steps: 20 trigger steps in the parent (well under 500), each child build handles its own 30 steps. Each triggered build gets its own job limits.
+3. **Request a quota increase** when workloads genuinely exceed defaults.
+
+## Job count surprises
+
+**Symptom.** The build hits the 4,000 jobs-per-build limit unexpectedly.
+
+Three things people miss:
+
+1. **Parallelism multiplies.** `parallelism: 10` = 10 jobs.
+2. **Retries count.** Each retry attempt is a separate job. `automatic_retry` with `limit: 2` produces up to 3 jobs per step (original + 2 retries).
+3. **Retrying the upload step re-uploads.** If the bootstrap step retries and is not using `--replace` or step keys, it uploads everything again, doubling the job count.
+
+**The math.** `(steps × parallelism) + (steps × max_retries)`. Close to 4,000 means fan out with trigger steps or reduce `parallelism` using Test Engine timing-based test splitting (see the **buildkite-test-engine** skill).
+
+## Upload performance at scale
+
+**What happens.** After `pipeline upload`, the control plane parses, validates, and merges steps into the running build. The agent waits for processing, polling with dynamic backoff (max 60 retries, Retry-After clamped 1s–30s). Small uploads finish in under a second. Uploads of hundreds of steps can take significantly longer; very large uploads can hit the server-side processing timeout.
+
+**Symptom.** Generator step takes a long time before the next steps appear. Or HTTP 529 returned to the agent followed by retries. Or the upload is ultimately rejected.
+
+**Fix.** Split into multiple smaller uploads inside the generator:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+for service in api web worker payments notifications search; do
+  cat <<YAML | buildkite-agent pipeline upload
+steps:
+  - label: ":test_tube: Test ${service}"
+    command: "make test -C services/${service}"
+    key: "test-${service}"
+  - label: ":rocket: Deploy ${service}"
+    command: "make deploy -C services/${service}"
+    depends_on: "test-${service}"
+YAML
+done
+```
+
+Each upload is small enough to process quickly. Use `depends_on` for execution order — multiple uploads from a single step appear in reverse order on the build (see next section).
+
+For workloads beyond what splitting can fix, use trigger steps to fan out across separate builds.
+
+## Step insertion order
+
+**Symptom.** Steps appear in the build in a different order than the generator emitted them.
+
+**Why.** `pipeline upload` inserts new steps immediately after the step that called it. When a single step calls `pipeline upload` three times (batches A, then B, then C), they appear as **C, B, A** in the build — each new batch is inserted at the same position, pushing earlier batches down.
+
+**Fix.** Declare execution order with `depends_on` between keys:
+
+```yaml
+- label: "Build"
+  key: "build"
+  command: "make build"
+
+- label: "Test"
+  key: "test"
+  depends_on: "build"
+  command: "make test"
+```
+
+## Environment variable interpolation
+
+**Symptom.** A generated step references `$SOME_VAR` and the variable is empty or wrong when the step runs.
+
+**Why.** The agent interpolates `$VAR` and `${VAR}` at **upload time**, before generated steps run. A variable that does not exist in the generator step's environment (or whose value differs from what the step will see at runtime) resolves to whatever is in the generator's environment — often empty.
+
+The most common case: a step's own `env:` block does not take effect until the step runs, so referencing those values with `$VAR` in the same step's `command:` resolves to empty at upload time.
+
+**Fix.** Escape `$` to defer evaluation:
+
+```yaml
+# Wrong: $DEPLOY_TARGET is empty at upload time
+- command: "deploy.sh $DEPLOY_TARGET"
+  env:
+    DEPLOY_TARGET: "production"
+
+# Right: $$ defers evaluation to step runtime
+- command: "deploy.sh $$DEPLOY_TARGET"
+  env:
+    DEPLOY_TARGET: "production"
+```
+
+`\$VAR` works the same way as `$$VAR`.
+
+**Other interpolation patterns worth knowing:**
+
+```yaml
+# Required variable: upload fails if MY_VAR is unset
+command: "deploy.sh ${MY_VAR?}"
+
+# Default value at upload time
+command: "deploy.sh ${MY_VAR:-staging}"
+
+# Substring extraction (characters 0-7)
+label: "Commit ${BUILDKITE_COMMIT:0:7}"
+```
+
+To skip interpolation entirely on an upload:
+
+```bash
+buildkite-agent pipeline upload --no-interpolation
+```
+
+Useful when the generated YAML already contains the literal values needed, or when shell variables in commands would otherwise be consumed by the agent.
+
+## Duplicate steps after retry of an upload step
+
+**Symptom.** Retrying a failed generator step leaves the build with two copies of every generated step.
+
+**Why.** The step that calls `pipeline upload` runs again on retry. The first run already uploaded steps; the retry uploads them again. Subsequent uploads add alongside existing steps — they do not replace them.
+
+**Fixes (pick the one that fits):**
+
+- **Set `key:` on every generated step.** The Buildkite server raises `DuplicateKeyError` when a key already exists in the build, so the second upload fails loudly instead of silently duplicating. This is the right default.
+- **Use `--replace`** when the upload step is responsible for the entire downstream pipeline. `--replace` soft-deletes pending steps before adding new ones (jobs already running are not affected). Do not use `--replace` when multiple steps each upload their own portion — a retry of one step would wipe steps uploaded by others.
+- **Design for idempotency.** A generator can check the build via the API and skip re-uploading steps that already exist.
+
+## Concurrency in dynamically generated steps
+
+**Symptom.** Concurrency limits do not work as expected. Steps that should share a limit do not, or steps that should not share one do.
+
+**Why.** Concurrency group names get interpolated at upload time. A generator emitting `"deploy/$SERVICE/production"` resolves `$SERVICE` from the **generator's** environment, not from each generated step's environment. The literal string at upload time is whatever `$SERVICE` happened to be (often empty), so steps share or do not share groups unexpectedly.
+
+**Fix.** Compute the literal string in the generator:
+
+```python
+# Python generator
+for service in changed_services:
+    pipeline.add_step({
+        "label": f"Deploy {service}",
+        "command": f"deploy.sh {service}",
+        "concurrency": 1,
+        "concurrency_group": f"deploy/{service}/production",  # literal
+    })
+```
+
+```bash
+# Bash generator
+for service in $CHANGED_SERVICES; do
+  cat <<YAML
+- label: "Deploy ${service}"
+  command: "deploy.sh ${service}"
+  concurrency: 1
+  concurrency_group: "deploy/${service}/production"
+YAML
+done
+```
+
+**Concurrency groups are organisation-scoped**, not build-scoped. Two pipelines using `"deploy/auth/production"` share the limit globally.
+
+**Concurrency attributes only work on command steps**, not on group steps. See `references/group-steps.md`.
+
+## Notifications on dynamically generated steps
+
+**Symptom.** Notifications do not fire on dynamically generated steps.
+
+**Why.** Two distinct issues:
+
+1. **Step-level notifications are not inherited.** Build-level `notify` in the initial `pipeline.yml` covers the whole build, including dynamically uploaded steps — repeating it is not needed. But step-level `notify` is per-step. A generated step that needs its own notification requires `notify:` emitted by the generator.
+2. **Build-level events that already fired do not replay.** A generator uploading a `notify` block after `build.started` already fired misses that event. Time-sensitive notifications belong in the bootstrap YAML.
+
+**Fix for step-level conditional notifications:**
+
+```yaml
+- label: ":rocket: Deploy to production"
+  command: "make deploy"
+  notify:
+    - slack:
+        channels: ["#deploys"]
+        message: "Production deploy failed"
+      if: step.outcome == "hard_failed"
+```
+
+`step.outcome` values: `"neutral"`, `"passed"`, `"soft_failed"`, `"hard_failed"`, `"errored"`.
+
+**Step-level supports:** Slack, GitHub checks, GitHub commit status, Basecamp.
+**Build-level only:** webhooks, PagerDuty, email.
+
+## Combining if and if_changed
+
+**Symptom.** A step needs "run when on main OR when these files changed" and a single step cannot express it.
+
+**Why.** `if` is evaluated at upload time before checkout. `if_changed` is evaluated during upload after the agent reads the diff. They combine with AND logic (both must be true) but not OR.
+
+**Fix.** A small generator script that evaluates both conditions:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+BRANCH="$BUILDKITE_BRANCH"
+CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+DEPLOY_FILES_CHANGED=$(echo "$CHANGED_FILES" | grep -c '^deploy/' || true)
+
+if [[ "$BRANCH" == "main" ]] || [[ "$DEPLOY_FILES_CHANGED" -gt 0 ]]; then
+  cat <<YAML | buildkite-agent pipeline upload
+steps:
+  - label: ":rocket: Deploy"
+    command: "make deploy"
+    key: "deploy"
+    agents:
+      queue: "deploy"
+YAML
+fi
+```
+
+This consumes an agent slot to evaluate the condition but gives full control over the logic. The standard upgrade path when teams outgrow `if_changed`.
+
+## Retry storms during infrastructure incidents
+
+**Symptom.** During an infrastructure issue (spot preemption, network outage, dependent service down), many jobs fail at once and all retry simultaneously, multiplying load on an already-broken fleet.
+
+**Why.** `automatic_retry` defaults to `limit: 2` when no limit is set. 200 steps × 2 retries = 400 retry jobs hitting the fleet during the outage.
+
+**Fix.**
+
+- **Set explicit `limit`** on every `automatic_retry` rule.
+- **Target specific exit codes**, not `exit_status: "*"` with high limits:
+  - `-1` agent lost (spot termination, network)
+  - `137` OOM kill (SIGKILL)
+  - `143` SIGTERM
+  - `255` timeout / SSH failure
+- **Use a different queue for retries** on infra failures instead of retrying on the same broken fleet. See `references/dynamic-pipeline-patterns.md` for the `pre-exit` hook pattern.
+- **Watch the per-build retry budget**: `(steps × max_retries)` counts toward the 4,000 jobs-per-build limit.
+
+## Pipeline signing with dynamic uploads
+
+Pipeline signing verifies that uploaded YAML has not been tampered with. With dynamic pipelines, the agent signs YAML at upload time.
+
+When signing is enabled and verification fails for dynamically uploaded steps, check that the generator's signing context matches what the verifier expects. See the **buildkite-secure-delivery** skill for signing setup.
+
+For pipelines that need strong supply chain guarantees, signing is the durable answer — block-step gating is a stopgap.
+
+## Further Reading
+
+- [Dynamic pipelines overview](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines.md)
+- [`pipeline upload` CLI reference](https://buildkite.com/docs/agent/v3/cli-pipeline.md)
+- [Platform limits](https://buildkite.com/docs/platform/limits.md)
+- [Environment variables](https://buildkite.com/docs/pipelines/configure/environment-variables.md)
+- [Notifications](https://buildkite.com/docs/pipelines/configure/notifications.md)

--- a/skills/buildkite-pipelines/references/group-steps.md
+++ b/skills/buildkite-pipelines/references/group-steps.md
@@ -1,0 +1,271 @@
+# Group Steps Reference
+
+Group steps collect related steps into collapsible UI sections. This reference covers the attributes they accept, how they behave in dynamic pipelines, and the gotchas that surprise teams in production.
+
+## Attributes accepted on a group
+
+| Attribute | Accepted? | Behaviour |
+|-----------|-----------|-----------|
+| `key` | Yes | Unique identifier. Other steps reference it via `depends_on`. Appears as `group_key` in REST API responses. Also accepted as `identifier`. |
+| `group` | Yes | Display name. Also accepted as `label`. |
+| `depends_on` | Yes | Group-level dependencies. No child step starts until all dependencies are met. |
+| `allow_dependency_failure` | Yes | Lets the group proceed even when a depended-upon step has failed. |
+| `if` | Yes | Pushed down to every child step. The group container still appears in the UI even when all children are conditionally omitted. |
+| `skip` | Yes | Pushed down to every child step. |
+| `notify` | Yes | Evaluated on the group itself. Group outcome resolves from children: error > hard fail > soft fail > pass > neutral. |
+| `concurrency` | **No** | Command-step only. Server rejects the upload. |
+| `concurrency_group` | **No** | Command-step only. Server rejects the upload. |
+| `concurrency_method` | **No** | Command-step only. Server rejects the upload. |
+
+Set `key` on every group. It is required for `depends_on` between groups, surfaces in the API as `group_key`, and must be unique within a build. Use descriptive keys (`tests-auth`, not `tests`) so they remain unique when groups proliferate.
+
+## DAG mode warning
+
+Adding any group step to a build automatically enables DAG (directed acyclic graph) mode for that build. In DAG mode, steps without explicit `depends_on` or `wait` between them run in **parallel**, not top-to-bottom.
+
+If the existing pipeline relied on top-to-bottom ordering without explicit dependencies, adding a group causes those steps to run concurrently — including any steps that should have run after the group. Add `depends_on` or `wait` steps to preserve ordering.
+
+Check for implicit ordering assumptions before introducing a group into an existing pipeline. This is the most common surprise when teams adopt groups.
+
+## Generating groups dynamically
+
+One group per service is the default monorepo pattern:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+CHANGED_FILES=$(git diff --name-only --merge-base origin/main)
+
+echo "steps:"
+
+for service_dir in services/*/; do
+  service=$(basename "$service_dir")
+  if echo "$CHANGED_FILES" | grep -q "^services/${service}/"; then
+    cat <<YAML
+  - group: ":package: ${service}"
+    key: "group-${service}"
+    steps:
+      - label: ":hammer: Build ${service}"
+        command: "make build -C services/${service}"
+        key: "build-${service}"
+      - label: ":test_tube: Test ${service}"
+        command: "make test -C services/${service}"
+        depends_on: "build-${service}"
+        key: "test-${service}"
+YAML
+  fi
+done
+```
+
+Each changed service gets its own collapsible group. Within each group, the test step waits for the build step via `depends_on`. The groups themselves run in parallel because no dependency is declared between them.
+
+Group by **service** in monorepo pipelines so each service has its own section. Group by **phase** (lint, unit tests, integration tests, deploy) in single-service pipelines. The goal is for any engineer to find a failed step without scrolling through unrelated output.
+
+## Ordering groups with depends_on
+
+```yaml
+steps:
+  - group: ":test_tube: Tests"
+    key: "tests"
+    steps:
+      - label: "Test auth"
+        command: "make test-auth"
+        key: "test-auth"
+      - label: "Test api"
+        command: "make test-api"
+        key: "test-api"
+
+  - group: ":rocket: Deploy"
+    key: "deploy"
+    depends_on: "tests"
+    steps:
+      - label: "Deploy to staging"
+        command: "make deploy-staging"
+        key: "deploy-staging"
+```
+
+If any step in `tests` fails, no step in `deploy` runs. To allow `deploy` to proceed when some tests fail, add `allow_dependency_failure: true` on the downstream group.
+
+Consecutive groups without `depends_on` or `wait` between them run in parallel.
+
+## Group merging across uploads
+
+Groups can merge across `pipeline upload` calls, but only under two specific conditions:
+
+1. The job running the upload is itself **inside a group**, AND
+2. The first step of the uploaded pipeline is a group with the **same label** as the enclosing group.
+
+If both hold, the uploaded steps are added to the existing group rather than creating a new one.
+
+### Example: merging works
+
+```yaml
+# .buildkite/pipeline.yml — the upload job is inside the "Setup" group
+steps:
+  - group: "Setup"
+    steps:
+      - label: "Initialise"
+        command: "init.sh"
+      - label: "Generate pipeline"
+        command: "buildkite-agent pipeline upload .buildkite/generated.yml"
+```
+
+```yaml
+# .buildkite/generated.yml — first step is a group with the same label
+steps:
+  - group: "Setup"
+    steps:
+      - label: "Build containers"
+        command: "docker build ."
+```
+
+`Build containers` appears inside the existing `Setup` group.
+
+### Example: merging does NOT work
+
+```yaml
+# .buildkite/pipeline.yml — upload job is at top level, not in a group
+steps:
+  - label: "Generate pipeline"
+    command: "buildkite-agent pipeline upload .buildkite/generated.yml"
+```
+
+```yaml
+# .buildkite/generated.yml
+steps:
+  - group: "Setup"
+    steps:
+      - label: "Build containers"
+        command: "docker build ."
+```
+
+A new `Setup` group is created. Merging only happens when the upload job itself is a member of a matching group.
+
+Merging also only applies to the **first step** of the uploaded pipeline. A matching group appearing second or later creates a new group.
+
+### Multiple generators producing the same group name
+
+When several generators each call `pipeline upload` separately, each upload creates its own groups. Two uploads that both produce `:test_tube: Tests` result in two separate groups in the UI. To avoid this:
+
+- Give each generator's groups distinct names (`:test_tube: Auth Tests`, `:test_tube: Payments Tests`), or
+- Consolidate the steps into a single upload.
+
+## Concurrency on group steps
+
+`concurrency`, `concurrency_group`, and `concurrency_method` are command-step attributes. The server rejects pipeline uploads that put them on a group:
+
+```
+"concurrency" is not a valid property on a group step
+```
+
+Set concurrency on each command step inside the group instead:
+
+```yaml
+- group: ":rocket: Deploy"
+  key: "deploy"
+  steps:
+    - label: "Deploy auth"
+      command: "make deploy-auth"
+      concurrency: 1
+      concurrency_group: "deploy/auth"
+    - label: "Deploy payments"
+      command: "make deploy-payments"
+      concurrency: 1
+      concurrency_group: "deploy/payments"
+```
+
+Different `concurrency_group` values queue separately: `deploy/auth` and `deploy/payments` can run concurrently across builds, but two `deploy/auth` jobs from different builds cannot.
+
+To serialise all deploys regardless of service, use the same `concurrency_group` (e.g. `"deploy"`) on every step. To cap parallelism against a shared resource without enforcing queue order, set `concurrency_method: eager`.
+
+## Groups can't nest
+
+A group inside another group is rejected:
+
+```
+Group steps can't be nested within groups
+```
+
+The workaround is flat groups with a `Category: Subcategory` naming convention:
+
+```yaml
+steps:
+  - group: ":test_tube: Backend: Auth Tests"
+    key: "backend-auth"
+    steps:
+      - label: "Auth unit tests"
+        command: "make test-auth-unit"
+      - label: "Auth integration tests"
+        command: "make test-auth-integration"
+
+  - group: ":test_tube: Backend: API Tests"
+    key: "backend-api"
+    steps:
+      - label: "API unit tests"
+        command: "make test-api-unit"
+      - label: "API integration tests"
+        command: "make test-api-integration"
+
+  - group: ":rocket: Deploy"
+    depends_on:
+      - "backend-auth"
+      - "backend-api"
+    steps:
+      - label: "Deploy to staging"
+        command: "make deploy-staging"
+```
+
+When a generator would naturally produce outer-team / inner-service nesting, restructure to flat `Team: Service` groups.
+
+## Job limits with grouped pipelines
+
+Group steps count toward the platform job limits. Each group is 1 job, plus 1 job per child command step (multiplied by `parallelism`).
+
+| Limit | Default |
+|-------|---------|
+| Jobs per `pipeline upload` | 500 |
+| Pipeline uploads per build | 500 |
+| Jobs per build | 4,000 |
+
+This pipeline produces 7 jobs:
+
+```yaml
+steps:
+  - group: ":test_tube: Tests"    # 1 job
+    key: "tests"
+    steps:
+      - label: "Unit tests"
+        command: "make test-unit"
+        parallelism: 3             # 3 jobs
+      - label: "Lint"
+        command: "make lint"       # 1 job
+
+  - group: ":rocket: Deploy"       # 1 job
+    depends_on: "tests"
+    steps:
+      - label: "Deploy"
+        command: "make deploy"     # 1 job
+```
+
+Exceeding the per-upload limit returns `The number of jobs in this upload exceeds your organization limit of 500`. Steps already in the build are unaffected; nothing from the rejected upload is added.
+
+### Three levers for reducing job count
+
+1. **Trigger steps to fan out.** Generate trigger steps that start separate builds per service instead of uploading all jobs into a single build. Each triggered build gets its own job limits. A monorepo with 20 services × 30 steps = 600 jobs in one build (rejected) becomes 20 trigger steps in the parent and 30 steps each in 20 child builds.
+2. **Test Engine instead of high `parallelism`.** A step with `parallelism: 10` counts as 10 jobs. Timing-based test splitting distributes tests evenly, so 4 well-balanced shards often replace 10 evenly-split ones. See the **buildkite-test-engine** skill.
+3. **Cap retries explicitly.** `automatic_retry` defaults to `limit: 2`. Across many steps during an outage, these retries multiply and contribute to the per-build limit.
+
+## No per-group collapse, no fast-cancel
+
+Two limitations worth knowing:
+
+**No per-group default collapse state.** All groups in a build share the same default collapse state on page load. There is no way to start some groups collapsed and others expanded. Use descriptive group names so engineers know which group to expand.
+
+**No built-in fast-cancel of sibling steps.** When only one result matters across a group (e.g. testing against multiple environments and using the first to pass), Buildkite has no native way to cancel the others when one succeeds or fails. Workaround: call the Buildkite REST API from inside the step command to cancel sibling jobs by key. See the **buildkite-api** skill.
+
+## Further Reading
+
+- [Group step reference](https://buildkite.com/docs/pipelines/configure/step-types/group-step.md)
+- [Controlling concurrency](https://buildkite.com/docs/pipelines/configure/workflows/controlling-concurrency.md)
+- [Platform limits](https://buildkite.com/docs/platform/limits.md)


### PR DESCRIPTION
## Summary

Adds detailed dynamic pipeline content to the buildkite-pipelines skill: a group steps reference, a troubleshooting guide, and advanced patterns (fan-out/fan-in, SDK generation, the handler pattern, finalizer steps). This content was developed as part of the dynamic pipelines examples project and fills gaps in the existing skill's coverage of dynamic pipeline features.

## New files

- `skills/buildkite-pipelines/references/group-steps.md` — group step deep-dive (attribute table including rejected concurrency attributes, DAG mode warning, merging-across-uploads rules, no-nesting workaround, job-limit impact)
- `skills/buildkite-pipelines/references/dynamic-pipeline-troubleshooting.md` — common errors (silent uploads, quota limits, env var interpolation, duplicate-on-retry, retry storms), debugging strategies, Common Mistakes table
- `skills/buildkite-pipelines/references/dynamic-pipeline-patterns.md` — fan-out/fan-in with `depends_on`, SDK-based generation, the handler pattern (read state → decide → upload), `--replace` variant, finalizer / always-run steps via `pre-exit` hooks, OOM retry on a different queue, trigger-based fan-out, centralised generation

## Updated

- `skills/buildkite-pipelines/SKILL.md` — enriched Dynamic Pipelines section: flags `set -euo pipefail` as the single most common failure mode, adds the `key:` discipline note, surfaces platform limits (500 per upload, 4,000 per build), mentions the Buildkite SDK, and points to the three new reference files. Additional Resources section lists the new files.

## Style compliance

- Imperative voice throughout, no second person
- No duplication with `advanced-patterns.md` (monorepo generators, basic `if_changed`, matrix builds remain there)
- Cross-references to other skills use the `see the **buildkite-[skill]** skill` pattern
- All code blocks syntactically correct

## Test plan

- [ ] Spot-check the Dynamic Pipelines section of SKILL.md renders correctly
- [ ] Verify internal `references/*.md` pointers resolve
- [ ] Confirm no overlap with `advanced-patterns.md` content
- [ ] Run any repo-level evals that exercise dynamic pipeline questions