### PR TITLE
Add CODEOWNERS for docs and product teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @buildkite/docs @buildkite/product


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning `@buildkite/docs` and `@buildkite/product` as default reviewers.

Going in ahead of flipping the repo to public so external PRs can't merge without approval from a Buildkite team member.