### PR TITLE
Fix customer-facing docs after going public

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "buildkite",
       "source": "./",
-      "description": "Buildkite skills for pipelines, agent runtime, CLI, API, platform engineering, secure delivery, and test engine"
+      "description": "Official Buildkite skills for Claude Code, Cursor, and other AI coding agents — pipelines, migration, preflight, agent runtime, CLI, and API"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buildkite",
-  "description": "Buildkite skills for pipelines, agent infrastructure, agent runtime, CLI, API, secure delivery, and test engine",
+  "description": "Official Buildkite skills for Claude Code, Cursor, and other AI coding agents — pipelines, migration, preflight, agent runtime, CLI, and API",
   "version": "1.0.0",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "buildkite-skills",
   "displayName": "Buildkite Skills",
   "version": "1.0.0",
-  "description": "Buildkite skills for pipelines, agent runtime, CLI, API, platform engineering, secure delivery, and test engine",
+  "description": "Official Buildkite skills for Claude Code, Cursor, and other AI coding agents — pipelines, migration, preflight, agent runtime, CLI, and API",
   "author": {
     "name": "Buildkite"
   },
@@ -17,11 +17,12 @@
     "continuous integration",
     "build automation",
     "agents",
-    "test-engine",
-    "api",
-    "oidc",
-    "secure-delivery",
-    "agent-infrastructure"
+    "claude-code",
+    "cursor",
+    "ai-agents",
+    "preflight",
+    "migration",
+    "api"
   ],
   "category": "developer-tools",
   "tags": [
@@ -30,10 +31,12 @@
     "pipelines",
     "agents",
     "continuous integration",
-    "test-engine",
-    "api",
-    "secure-delivery",
-    "agent-infrastructure"
+    "claude-code",
+    "cursor",
+    "ai-agents",
+    "preflight",
+    "migration",
+    "api"
   ],
   "skills": "./skills/"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,17 +8,12 @@ Installed via `npx skills add buildkite/skills` or manually copied into agent sk
 ```
 skills/                              # All skills live here
   buildkite-pipelines/               # Journey — pipeline YAML, step types, caching, parallelism
-  buildkite-test-engine/             # Journey — test splitting, flaky detection, bktec CLI
-  buildkite-secure-delivery/         # Journey — OIDC, Package Registry, SLSA provenance
   buildkite-migration/               # Journey — CI migration, bk pipeline convert, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket, GitLab CI
-  buildkite-agent-infrastructure/    # Journey — clusters, queues, hosted agents, SSO, audit
+  buildkite-preflight/               # Cross-cutting — bk preflight against local uncommitted changes
   buildkite-agent-runtime/           # Cross-cutting — buildkite-agent subcommands in job steps
   buildkite-cli/                     # Cross-cutting — bk CLI commands
   buildkite-api/                     # Cross-cutting — REST API, GraphQL, webhooks
 ```
-
-Internal tooling (eval dataset/runner, ralph orchestration) lives in a separate
-private repo: [buildkite/skills-internal-tools](https://github.com/buildkite/skills-internal-tools).
 
 ## Skill Architecture
 
@@ -59,4 +54,3 @@ Link to Buildkite docs for canonical reference; do not reproduce them.
 2. Review an existing complete skill as a quality benchmark
 3. Check the boundary table — never duplicate content owned by another skill
 4. Follow the section order: frontmatter, title, overview, quick start, feature sections, common mistakes, additional resources, further reading
-5. Run evals (in [skills-internal-tools](https://github.com/buildkite/skills-internal-tools)) to verify quality

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Buildkite Skills
 
-Skills that teach AI coding agents how to use [Buildkite](https://buildkite.com).
-Install them into your agent of choice so it can generate correct pipeline YAML,
-run CLI commands, call the API, configure agents, split tests, and ship securely.
+The official Buildkite skills for Claude Code, Cursor, and other AI coding
+agents. Install them into your agent of choice so it can generate correct
+pipeline YAML, run `bk` and `buildkite-agent` CLI commands, call the API,
+configure agents, and run preflight builds.
 
 ## Installation
 
@@ -29,9 +30,6 @@ cp -r skills/buildkite-agent-runtime .claude/skills/
 cp -r skills/buildkite-cli .claude/skills/
 cp -r skills/buildkite-api .claude/skills/
 cp -r skills/buildkite-migration .claude/skills/
-cp -r skills/buildkite-agent-infrastructure .claude/skills/
-cp -r skills/buildkite-secure-delivery .claude/skills/
-cp -r skills/buildkite-test-engine .claude/skills/
 
 # Cursor
 mkdir -p .cursor/skills
@@ -41,9 +39,6 @@ cp -r skills/buildkite-agent-runtime .cursor/skills/
 cp -r skills/buildkite-cli .cursor/skills/
 cp -r skills/buildkite-api .cursor/skills/
 cp -r skills/buildkite-migration .cursor/skills/
-cp -r skills/buildkite-agent-infrastructure .cursor/skills/
-cp -r skills/buildkite-secure-delivery .cursor/skills/
-cp -r skills/buildkite-test-engine .cursor/skills/
 ```
 
 ## Skills
@@ -55,10 +50,7 @@ Skills organized by what you are trying to accomplish.
 | Skill | Directory | Description |
 |-------|-----------|-------------|
 | **Pipelines** | [skills/buildkite-pipelines/](skills/buildkite-pipelines/SKILL.md) | Pipeline YAML, step types, plugins, caching, parallelism, dynamic pipelines, matrix builds, artifacts, hooks |
-| **Test Engine** | [skills/buildkite-test-engine/](skills/buildkite-test-engine/SKILL.md) | Test splitting, flaky detection, quarantine, bktec CLI, test collectors |
-| **Secure Delivery** | [skills/buildkite-secure-delivery/](skills/buildkite-secure-delivery/SKILL.md) | OIDC authentication, Package Registry, SLSA provenance, pipeline signing |
 | **Migration** | [skills/buildkite-migration/](skills/buildkite-migration/SKILL.md) | CI migration planning, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines, GitLab CI using `bk pipeline convert` |
-| **Platform Engineering** | [skills/buildkite-agent-infrastructure/](skills/buildkite-agent-infrastructure/SKILL.md) | Clusters, queues, hosted agents, agent config, pipeline templates, SSO, audit logging |
 
 ### Cross-Cutting Skills
 
@@ -95,7 +87,6 @@ For more on content strategy, see [CONVENTIONS.md](CONVENTIONS.md).
 2. Review an existing complete skill as a quality benchmark (e.g. `skills/buildkite-pipelines/SKILL.md`)
 3. Check the boundary table in CONVENTIONS.md — each topic is owned by exactly one skill
 4. Write your skill following the section order and style rules
-5. Run evals to verify quality (internal — see [buildkite/skills-internal-tools](https://github.com/buildkite/skills-internal-tools))
 
 ## Documentation
 

--- a/llms.txt
+++ b/llms.txt
@@ -10,18 +10,6 @@
 Path: skills/buildkite-pipelines/SKILL.md
 Topics: pipeline.yml, step types (command, wait, block, trigger, group, input), plugins, caching, parallelism, dynamic pipelines, matrix builds, artifacts, hooks, retry, concurrency, if_changed, notify
 
-### buildkite-test-engine
-Path: skills/buildkite-test-engine/SKILL.md
-Topics: test splitting, bktec CLI, flaky detection, quarantine, test collectors, test suites, BUILDKITE_TEST_ENGINE_* env vars, test reliability scores
-
-### buildkite-secure-delivery
-Path: skills/buildkite-secure-delivery/SKILL.md
-Topics: OIDC authentication, Package Registry, SLSA provenance, pipeline signing, JWKS, cosign, attestation, credential-free publishing
-
-### buildkite-agent-infrastructure
-Path: skills/buildkite-agent-infrastructure/SKILL.md
-Topics: clusters, queues, hosted agent instance shapes, cluster secrets, buildkite-agent.cfg, agent tokens, lifecycle hooks, pipeline templates, audit logging, SSO/SAML, cost optimization
-
 ### buildkite-migration
 Path: skills/buildkite-migration/SKILL.md
 Topics: CI migration planning, bk pipeline convert, converting from GitHub Actions, Jenkins, CircleCI, Bitbucket Pipelines, GitLab CI, vendor auto-detection, pipeline best practices for migrated pipelines


### PR DESCRIPTION
## Summary

Customer test of the now-public repo found a handful of docs/manifest issues. Fixing the ones that don't depend on other in-flight work.

- README, AGENTS.md, llms.txt and both plugin manifests referenced three skills (`buildkite-test-engine`, `buildkite-secure-delivery`, `buildkite-agent-infrastructure`) that aren't on `main` — links 404 for logged-out visitors and `cp -r` snippets fail. PRs #18, #19, #20 would restore the skills themselves; doc updates can come with those merges.
- README + AGENTS pointed at `buildkite/skills-internal-tools` (private, 404 for customers) and at `evals/README.md` (directory not on main).
- Top-line phrasing was generic ("Skills that teach AI coding agents…"). Reworded to "the official Buildkite skills for Claude Code, Cursor, and other AI coding agents" so natural queries like "claude code buildkite" / "buildkite ai agent skill" resolve here.
- Cursor + Claude plugin manifests had description strings listing skills that don't ship; brought them in line and added `claude-code`/`cursor`/`ai-agents` keywords.

## Out of scope (separate work)

- GitHub repo description ("Shared skills repository") and homepage URL — those live in `saas-iac` Terraform; description PR coming next, homepage is a marketing question.
- Restoring the three missing skills — covered by #18 / #19 / #20.

## Test plan

- [ ] All `skills/buildkite-*` paths in README and llms.txt resolve to a real `SKILL.md` on this branch
- [ ] No remaining links to `buildkite/skills-internal-tools` or `evals/README.md`
- [ ] `npx skills add buildkite/skills` lists the same 6 skills as the README
- [ ] JSON manifests parse (validated locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)