### PR TITLE
skills: note MCP rate limits are separate from the org REST budget

### DIFF
--- a/skills/buildkite-api/SKILL.md
+++ b/skills/buildkite-api/SKILL.md
@@ -17,6 +17,10 @@ Buildkite exposes a REST API and a GraphQL API for programmatic automation, plus
 
 > To execute API calls interactively from the terminal, see the **buildkite-cli** skill for `bk api` commands. To use the Buildkite MCP server for direct agent access to builds, logs, and pipelines, the MCP server exposes its own tool schemas — no API construction needed.
 
+## Rate Limits
+
+Traffic through the Buildkite MCP server counts against a separate rate limit from the org-wide REST API budget. A 429 from an MCP call is the MCP-specific limit, not your production API allowance. See [[platform limits](https://buildkite.com/docs/platform/limits)](https://buildkite.com/docs/platform/limits) for exact numbers.
+
 ## Quick Start
 
 List builds for a pipeline using the REST API:

--- a/skills/buildkite-api/SKILL.md
+++ b/skills/buildkite-api/SKILL.md
@@ -17,10 +17,6 @@ Buildkite exposes a REST API and a GraphQL API for programmatic automation, plus
 
 > To execute API calls interactively from the terminal, see the **buildkite-cli** skill for `bk api` commands. To use the Buildkite MCP server for direct agent access to builds, logs, and pipelines, the MCP server exposes its own tool schemas — no API construction needed.
 
-## Rate Limits
-
-Traffic through the Buildkite MCP server counts against a separate rate limit from the org-wide REST API budget. A 429 from an MCP call is the MCP-specific limit, not your production API allowance. See [[platform limits](https://buildkite.com/docs/platform/limits)](https://buildkite.com/docs/platform/limits) for exact numbers.
-
 ## Quick Start
 
 List builds for a pipeline using the REST API:
@@ -40,6 +36,10 @@ curl -sS -X POST "https://graphql.buildkite.com/v1" \
     "query": "{ pipeline(slug: \"my-org/my-pipeline\") { builds(first: 5) { edges { node { state message } } } } }"
   }' | jq '.data.pipeline.builds.edges[].node'
 ```
+
+## Rate Limits
+
+Traffic through the Buildkite MCP server counts against a separate rate limit from the org-wide REST API budget. A 429 from an MCP call is the MCP-specific limit, not your production API allowance. See [platform limits](https://buildkite.com/docs/platform/limits) for exact numbers.
 
 ## Authentication
 

--- a/steering/api.md
+++ b/steering/api.md
@@ -32,6 +32,10 @@ curl -sS -X POST "https://graphql.buildkite.com/v1" \
   }' | jq '.data.pipeline.builds.edges[].node'
 ```
 
+## Rate Limits
+
+Traffic through the Buildkite MCP server counts against a separate rate limit from the org-wide REST API budget. A 429 from an MCP call is the MCP-specific limit, not your production API allowance. See [platform limits](https://buildkite.com/docs/platform/limits) for exact numbers.
+
 ## Authentication
 
 ### Bearer Token


### PR DESCRIPTION
Customer feedback showed engineers can be reluctant to enable agentic MCP because they assume it eats into their production API budget. It does not. MCP has its own rate limit. This adds a short paragraph to the buildkite-api skill so agents give the correct answer when a user asks.