### PR TITLE
Recommend lightweight build and job lookups

### DIFF
--- a/skills/buildkite-api/SKILL.md
+++ b/skills/buildkite-api/SKILL.md
@@ -15,7 +15,7 @@ description: >
 
 Buildkite exposes a REST API and a GraphQL API for programmatic automation, plus webhooks for event-driven integrations. Use the REST API for straightforward CRUD operations on builds, pipelines, and organizations. Use the GraphQL API for mutations (queue creation, template management, cluster operations) and when fetching nested or specific fields. Use webhooks to react to build and agent events in real time.
 
-> To execute API calls interactively from the terminal, see the **buildkite-cli** skill for `bk api` commands. To use the Buildkite MCP server for direct agent access to builds, logs, and pipelines, the MCP server exposes its own tool schemas — no API construction needed.
+> To execute API calls interactively from the terminal, see the **buildkite-cli** skill for `bk api` commands. With the Buildkite MCP server, use `list_builds` and `get_build` for build metadata without jobs or expanded pipeline information; use `list_jobs` and `get_job` only when job details are needed.
 
 ## Quick Start
 
@@ -23,7 +23,8 @@ List builds for a pipeline using the REST API:
 
 ```bash
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?per_page=5" | jq '.[].state'
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?exclude_jobs=true&exclude_pipeline=true&per_page=5" \
+  | jq '.[].state'
 ```
 
 Query the same data via GraphQL:
@@ -91,6 +92,8 @@ Base URL: `https://api.buildkite.com/v2`
 
 All responses return JSON. Use `Content-Type: application/json` for request bodies.
 
+Default build list and get requests to `exclude_jobs=true`. Also set `exclude_pipeline=true` unless expanded pipeline information is required. Retrieve jobs from the Jobs API rather than expanding every job into a build response.
+
 ### Endpoint Reference
 
 All endpoints are under `/organizations/{org.slug}`. Abbreviated as `/{org}` below.
@@ -104,7 +107,7 @@ All endpoints are under `/organizations/{org.slug}`. Abbreviated as `/{org}` bel
 | Builds (org) | `/{org}/builds` | GET | `read_builds` |
 | Builds (pipeline) | `/{org}/pipelines/{slug}/builds` | GET, POST | `read_builds`, `write_builds` |
 | Build | `/{org}/pipelines/{slug}/builds/{num}` | GET | `read_builds` |
-| Jobs | `/{org}/pipelines/{slug}/builds/{num}/jobs` | GET | `read_builds` |
+| Jobs (build) | `/{org}/pipelines/{slug}/builds/{num}/jobs` | GET | `read_builds` |
 | Job log | `/{org}/pipelines/{slug}/builds/{num}/jobs/{id}/log` | GET, DELETE | `read_build_logs` |
 | Job env | `/{org}/pipelines/{slug}/builds/{num}/jobs/{id}/env` | GET | `read_job_env` |
 | Artifacts (build) | `/{org}/pipelines/{slug}/builds/{num}/artifacts` | GET | `read_artifacts` |
@@ -121,11 +124,11 @@ All endpoints are under `/organizations/{org.slug}`. Abbreviated as `/{org}` bel
 
 ### Pagination
 
-REST responses are paginated using HTTP `Link` headers:
+Most REST list responses are paginated using HTTP `Link` headers. The List Jobs endpoint instead returns cursor links in the response body, as described below.
 
 ```
-Link: <https://api.buildkite.com/v2/organizations/my-org/builds?page=2&per_page=30>; rel="next",
-      <https://api.buildkite.com/v2/organizations/my-org/builds?page=5&per_page=30>; rel="last"
+Link: <https://api.buildkite.com/v2/organizations/my-org/builds?exclude_jobs=true&exclude_pipeline=true&page=2&per_page=30>; rel="next",
+      <https://api.buildkite.com/v2/organizations/my-org/builds?exclude_jobs=true&exclude_pipeline=true&page=5&per_page=30>; rel="last"
 ```
 
 | Parameter | Default | Max | Description |
@@ -140,7 +143,7 @@ Parse the `Link` header to follow `rel="next"` until no next link exists.
 ```bash
 # Filter by state and branch
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?state=failed&branch=main"
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?exclude_jobs=true&exclude_pipeline=true&state=failed&branch=main"
 ```
 
 Build list query parameters:
@@ -153,8 +156,33 @@ Build list query parameters:
 | `commit` | Commit SHA | `commit=abc123` |
 | `created_from` | Builds after (ISO 8601) | `created_from=2024-01-01T00:00:00Z` |
 | `created_to` | Builds before (ISO 8601) | `created_to=2024-12-31T23:59:59Z` |
+| `exclude_jobs` | Exclude embedded jobs; use for state polling and metadata | `exclude_jobs=true` |
+| `exclude_pipeline` | Exclude expanded pipeline information | `exclude_pipeline=true` |
 | `include_retried_jobs` | Include retried executions | `include_retried_jobs=true` |
 | `meta_data` | Filter by metadata | `meta_data[deploy]=true` |
+
+### Get a Build
+
+Use a build number, not a build UUID. Keep metadata and status checks lightweight:
+
+```bash
+curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42?exclude_jobs=true&exclude_pipeline=true"
+```
+
+Omit an exclusion only when the response must include that expansion.
+
+### List Jobs
+
+Query jobs directly once the build number is known. Do not fetch the build again with embedded jobs. The endpoint supports server-side state filtering, including `failed` jobs in large or still-running builds.
+
+```bash
+curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?state[]=failed&include_retried_jobs=false&per_page=100" \
+  | jq '.items[] | {id, name, state, exit_status, web_url}'
+```
+
+This endpoint uses cursor pagination: read jobs from `.items` and follow `.links.next` until it is `null`. `include_retried_jobs` defaults to `true`; set it to `false` when only the latest attempt for each step is needed.
 
 ### Create a Build
 
@@ -248,7 +276,9 @@ Endpoint: `https://graphql.buildkite.com/v1`. The GraphQL API supports queries a
 | Scenario | Use | Why |
 |----------|-----|-----|
 | Trigger a build | Either | Both support it; REST is simpler |
+| Poll build state or read metadata | REST | Set `exclude_jobs=true&exclude_pipeline=true` to avoid unused expansions |
 | List builds with filtering | REST | Better query parameter support |
+| List jobs for one build | REST Jobs API | Server-side job filtering without expanding the build response |
 | Fetch build + jobs + artifacts in one call | GraphQL | Single request, no N+1 |
 | Simple CRUD on pipelines, clusters, queues | REST | Simpler request/response |
 | Audit events | GraphQL | `auditEvent` query available |
@@ -266,6 +296,7 @@ Most commonly used events: `build.finished` (react to build completion), `job.fi
 
 | Mistake | What happens | Fix |
 |---------|-------------|-----|
+| Polling build list/get endpoints with embedded jobs | Repeatedly transfers every job and expanded pipeline data | Add `exclude_jobs=true&exclude_pipeline=true`; query the Jobs API only when job details are needed |
 | Using pipeline slug as GraphQL `pipelineID` | Mutation fails with "not found" error | Query the pipeline first to get its `id` (base64-encoded GraphQL node ID), then use that in mutations |
 | Missing `Content-Type: application/json` on POST requests | 422 error or empty response body | Always include `-H "Content-Type: application/json"` for POST/PUT/PATCH requests |
 | Not following `Link` header pagination | Only get first 30 results, missing data | Parse the `Link` header for `rel="next"` and loop until no next link exists |

--- a/skills/buildkite-api/references/patterns.md
+++ b/skills/buildkite-api/references/patterns.md
@@ -11,7 +11,7 @@ pipeline="my-pipeline"
 since=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
 
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/$org/pipelines/$pipeline/builds?state=failed&created_from=$since&per_page=100" \
+  "https://api.buildkite.com/v2/organizations/$org/pipelines/$pipeline/builds?exclude_jobs=true&exclude_pipeline=true&state=failed&created_from=$since&per_page=100" \
   | jq '.[] | {number, branch, message, web_url}'
 ```
 
@@ -19,7 +19,7 @@ curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
 
 ```bash
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?per_page=100&branch=main" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?exclude_jobs=true&exclude_pipeline=true&per_page=100&branch=main" \
   | jq '{
     total: length,
     passed: [.[] | select(.state == "passed")] | length,
@@ -27,6 +27,18 @@ curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
     pass_rate: (([.[] | select(.state == "passed")] | length) * 100.0 / length)
   }'
 ```
+
+## Fetch Failed Jobs for a Build
+
+Use the Jobs API instead of fetching the build with embedded jobs:
+
+```bash
+curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?state[]=failed&include_retried_jobs=false&per_page=100" \
+  | jq '.items[] | {id, name, state, exit_status, web_url}'
+```
+
+Follow `.links.next` when it is not `null`.
 
 ## Trigger Downstream Pipeline
 

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -22,6 +22,8 @@ The Buildkite CLI (`bk`) provides terminal access to builds, jobs, pipelines, se
 
 ## Quick Start
 
+`bk job list --build` requires Buildkite CLI v3.53.0 or later. Run `bk update` if the flag is unavailable.
+
 ```bash
 # Install
 brew install buildkite/buildkite/bk
@@ -35,8 +37,9 @@ bk build create
 # Watch the most recent build run
 bk build watch
 
-# Inspect a build and read a failed job's log
-bk build view
+# Inspect build state, find failed jobs, and read a failed job's log
+bk build view 429 --summary
+bk job list --pipeline my-app --build 429 --state failed
 bk job log <job-uuid>
 ```
 
@@ -151,24 +154,25 @@ bk build create -w
 
 `bk build view` (and most build commands) default to the most recent build on the current branch.
 
+Use `--summary` for status checks, polling, scripts, and agent workflows. It excludes jobs and expanded pipeline information, and skips artifact and annotation requests.
+
 ```bash
-bk build view                  # most recent build on the current branch
-bk build view 429              # a specific build number
-bk build view -s failed,broken # only show failed/broken jobs
-bk build view --mine           # most recent build by the current user
-bk build view 429 -o json      # structured output
+bk build view --summary             # latest build metadata and state
+bk build view 429 --summary         # a specific build number
+bk build view 429 --summary -o json # compact structured output
+bk build view --mine --summary      # latest build by the current user
 ```
 
 ### List builds
 
 ```bash
-bk build list                                   # 50 most recent
-bk build list --state failed --branch main      # filter by state and branch
-bk build list --since 24h --duration ">20m"     # recent slow builds
-bk build list --meta-data env=production -o json
+bk build list --summary                              # 50 compact build summaries
+bk build list --summary --state failed --branch main # filter by state and branch
+bk build list --summary --since 24h                  # recent build states
+bk build list --summary --meta-data env=production -o json
 ```
 
-Server-side filters (fast): `--pipeline`, `--since`, `--until`, `--state`, `--branch`, `--creator`, `--commit`, `--meta-data`. Client-side filters: `--duration`, `--message`. Valid states: `running`, `scheduled`, `passed`, `failed`, `blocked`, `canceled`, `canceling`, `skipped`, `not_run`. Pass `--state` and `--branch` as comma-separated lists. Use `--limit N` (default 50) or `--no-limit` to control paging. See `references/command-reference.md` for the full filter table.
+Use `--summary` for metadata-only output; the API requests exclude jobs and expanded pipeline information. Server-side filters (fast): `--pipeline`, `--since`, `--until`, `--state`, `--branch`, `--creator`, `--commit`, `--meta-data`. Client-side filters: `--duration`, `--message`. Valid states: `running`, `scheduled`, `passed`, `failed`, `blocked`, `canceled`, `canceling`, `skipped`, `not_run`. Pass `--state` and `--branch` as comma-separated lists. Use `--limit N` (default 50) or `--no-limit` to control paging. See `references/command-reference.md` for the full filter table.
 
 ### Watch a build
 
@@ -215,12 +219,21 @@ bk job log <job-uuid> --no-timestamps   # strip timestamp prefixes
 
 ### List jobs
 
-`bk job list` extracts jobs across recent builds, with server-side (`--pipeline`, `--since`, `--until`) and client-side (`--queue`, `--state`, `--duration`) filters.
+When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state` is applied server-side; `--queue` and `--duration` remain client-side.
+
+```bash
+bk job list --pipeline my-app --build 429 --state failed
+bk job list --build 429 --state running # pipeline auto-detected
+```
+
+Without `--build`, the command searches across recent builds and extracts their embedded jobs:
 
 ```bash
 bk job list --queue test-queue --state running
 bk job list --duration ">10m" --order-by duration --no-limit
 ```
+
+`--limit` caps the total jobs emitted, not the API page size. Use `--no-limit` to follow every cursor page. `--since` and `--until` cannot be combined with `--build`.
 
 ### Retry, cancel, unblock, reprioritize
 
@@ -235,9 +248,9 @@ bk job reprioritize <job-uuid> 10 # raise scheduling priority
 ### Debugging workflow
 
 ```bash
-bk build list --state failed -p my-app   # find failed builds
-bk build view 429 -p my-app -s failed    # identify the failed jobs
-bk job log <job-uuid>                     # read the failing log
+bk build list --summary --state failed -p my-app
+bk job list --pipeline my-app --build 429 --state failed
+bk job log <job-uuid>
 ```
 
 ## Pipelines
@@ -380,9 +393,9 @@ bk skill add buildkite-api   # install a Buildkite skill into the current agent
 Make direct REST or GraphQL calls with `bk api`:
 
 ```bash
-bk api /pipelines/my-app/builds/429                    # REST GET (org inferred)
+bk api '/pipelines/my-app/builds/429?exclude_jobs=true&exclude_pipeline=true'
 bk api -X POST /pipelines --data '{"name":"New","repository":"git@..."}'
-bk api --file query.graphql                                      # GraphQL (file with a named operation)
+bk api --file query.graphql # GraphQL file with a named operation
 ```
 
 > For comprehensive REST and GraphQL documentation (endpoints, mutations, pagination, webhooks), see the **buildkite-api** skill.
@@ -394,7 +407,9 @@ When the Buildkite MCP server is available, prefer MCP tools for read operations
 | CLI Command | MCP Tool | Notes |
 |-------------|----------|-------|
 | `bk build create` | `create_build` | MCP handles auth automatically |
-| `bk build view` / `list` | `get_build` / `list_builds` | Same filters; structured output |
+| `bk build view --summary` / `list --summary` | `get_build` / `list_builds` | Metadata only; jobs and expanded pipeline information are excluded |
+| `bk job list --build` | `list_jobs` | List jobs without expanding the build response |
+| — | `get_job` | MCP-only single-job metadata lookup |
 | `bk job log` | `read_logs`, `tail_logs` | MCP supports streaming |
 | `bk pipeline list` / `view` / `create` | `list_pipelines`, `get_pipeline`, `create_pipeline` | |
 | `bk artifacts list` / `download` | `list_artifacts_for_build`, `get_artifact` | |
@@ -409,13 +424,15 @@ When the Buildkite MCP server is available, prefer MCP tools for read operations
 
 | Mistake | What happens | Fix |
 |---------|-------------|-----|
+| Using full build responses for status polling | Downloads jobs, pipeline details, artifacts, and annotations repeatedly | Use `bk build view --summary` or `bk build list --summary` |
+| Omitting `--build` when the build number is known | Scans recent build responses and extracts their embedded jobs | Use `bk job list --pipeline my-app --build 429`, or MCP `list_jobs` |
 | Running `bk` commands before authenticating | Commands fail with authentication errors | Run `bk auth login` (or `bk configure` with a token) first |
 | Running `bk auth login` in Docker/CI expecting a browser | Hangs — no browser or keychain available | Use `bk auth login --org my-org --token "$TOKEN"`, or `--device` for headless |
 | Passing `-p`/`-b` to `bk job log` | Flags are deprecated and ignored — job UUIDs are self-contained | Pass only the job UUID |
 | Retrying a job UUID that was already retried | API returns 422 — each UUID retries once | Use the new job UUID returned by the first retry |
 | Creating secrets with keys starting with `buildkite`/`bk` | Creation fails — reserved prefix | Choose another name (exception: `BUILDKITE_API_TOKEN`) |
 | Passing secret values literally in `--value` | Values persist in shell history and process list | Use env var references (`--value "$TOKEN"`) or the masked prompt |
-| Running `bk build cancel` on a finished build | API errors — only scheduled/running/failing builds cancel | Check state with `bk build view` first |
+| Running `bk build cancel` on a finished build | API errors — only scheduled/running/failing builds cancel | Check state with `bk build view --summary` first |
 | Assuming `bk artifacts upload` exists | No such command | Upload from a job with `buildkite-agent artifact upload` |
 | Confusing `bk` with `buildkite-agent` | `bk` runs locally against the API; `buildkite-agent` runs inside job steps | Use `bk` from a terminal, `buildkite-agent` inside pipeline commands |
 

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -166,9 +166,9 @@ bk build view --mine --summary      # latest build by the current user
 ### List builds
 
 ```bash
-bk build list --summary                              # 50 compact build summaries
+bk build list --summary                              # 50 most recent build summaries
 bk build list --summary --state failed --branch main # filter by state and branch
-bk build list --summary --since 24h                  # recent build states
+bk build list --summary --since 24h --duration ">20m" # slow builds from the last 24 hours
 bk build list --summary --meta-data env=production -o json
 ```
 

--- a/skills/buildkite-cli/references/command-reference.md
+++ b/skills/buildkite-cli/references/command-reference.md
@@ -92,13 +92,14 @@ bk organization list    # alias bk org list; JSON by default
 | `--message` | — | — | Filter by message content | client |
 | `--limit` | — | `50` | Maximum builds to return | — |
 | `--no-limit` | — | `false` | Fetch all builds (overrides `--limit`) | — |
+| `--summary` | — | `false` | Return metadata only; exclude jobs and expanded pipeline information | server/output |
 | `--output` | `-o` | `text` | Output format: `text`, `json`, `yaml` (or `--json`/`--yaml`/`--text`) | — |
 
 Valid states: `running`, `scheduled`, `passed`, `failed`, `blocked`, `canceled`, `canceling`, `skipped`, `not_run`.
 
 ### `bk build view` / `rebuild` / `download`
 
-These default to the most recent build on the current branch. Shared flags: `-p/--pipeline`, `-b/--branch`, `-u/--user`, `--mine`, `-w/--web` (view and rebuild). `bk build view` adds `-s/--job-states` (comma-separated: `running`, `scheduled`, `passed`, `failed`, `canceled`, `skipped`, `not_run`, `broken`) and output flags.
+These default to the most recent build on the current branch. Shared flags: `-p/--pipeline`, `-b/--branch`, `-u/--user`, `--mine`, `-w/--web` (view and rebuild). `bk build view` adds `-s/--job-states` (comma-separated: `running`, `scheduled`, `passed`, `failed`, `canceled`, `skipped`, `not_run`, `broken`), `--summary`, and output flags. Summary mode excludes jobs and expanded pipeline information and skips artifact and annotation requests; use it for status polling and metadata reads.
 
 ### `bk build watch`
 
@@ -112,17 +113,20 @@ These default to the most recent build on the current branch. Shared flags: `-p/
 
 ### `bk job list`
 
+Pass `--build` when the build number is known. This uses the dedicated cursor-paginated List Jobs endpoint instead of searching build responses. The pipeline can be passed with `--pipeline` or resolved from the current repository or configuration. `--limit` remains the total output cap; `--no-limit` follows every cursor page. `--since` and `--until` cannot be combined with `--build`.
+
 | Flag | Default | Description | Side |
 |------|---------|-------------|------|
 | `--pipeline` (`-p`) | — | Filter by pipeline slug | server |
+| `--build` | — | Filter by build number; requires a resolvable pipeline | server |
 | `--since` | — | Builds created since (e.g. `1h`) | server |
 | `--until` | — | Builds created before (e.g. `1h`) | server |
 | `--queue` | — | Filter by queue name | client |
-| `--state` | — | Filter by job state (comma-separated) | client |
+| `--state` | — | Filter by job state (comma-separated) | server with `--build`; client otherwise |
 | `--duration` | — | Filter by duration (`>10m`, `<5m`, …) | client |
 | `--order-by` | — | Order by `start_time` or `duration` | — |
-| `--limit` | `100` | Maximum jobs to return | — |
-| `--no-limit` | `false` | Fetch all matching jobs (scans up to 200 builds otherwise) | — |
+| `--limit` | `100` | Maximum total jobs to return | — |
+| `--no-limit` | `false` | Fetch every jobs page; without `--build`, also scan beyond the default 200 builds | — |
 
 Other job commands: `bk job retry <uuid>`, `bk job cancel <uuid> [-w]`, `bk job unblock <uuid> [--data '<json>']`, `bk job reprioritize <uuid> <priority>`. The `-p`/`-b` flags on `bk job log` and `bk job reprioritize` are deprecated and ignored — job UUIDs no longer need build context.
 
@@ -200,8 +204,8 @@ Supports Docker images, npm, Debian, RPM, and generic file uploads. Push to Buil
 ## Raw API Access
 
 ```bash
-# REST GET (organization inferred from config)
-bk api /pipelines/example-pipeline/builds/420
+# REST GET build metadata (organization inferred from config)
+bk api '/pipelines/example-pipeline/builds/420?exclude_jobs=true&exclude_pipeline=true'
 
 # REST POST
 bk api --method POST /pipelines --data '{

--- a/skills/buildkite-preflight/SKILL.md
+++ b/skills/buildkite-preflight/SKILL.md
@@ -172,7 +172,7 @@ Check the exit code to determine the build result:
 
 ## Optional Workflow: Act On A Failure And Check Back Later
 
-Begin fixing the first failure as soon as preflight exits with an incomplete build result because the build is failing, and then check back on the same build with `bk build view` for subsequent failures. This allows you to quickly iterate on the first failure, and gather further failures in parallel. Use the `bk preflight --no-cleanup` option to ensure that build is not cancled on fast failure.
+Begin fixing the first failure as soon as preflight exits with an incomplete build result because the build is failing. Check the same build's summary while it continues, then query failed jobs directly for subsequent failures. This allows you to quickly iterate on the first failure, and gather further failures in parallel. Use the `bk preflight --no-cleanup` option to ensure that build is not canceled on fast failure.
 
 ```bash
 bk preflight --pipeline my-org/my-pipeline --watch --no-cleanup --text
@@ -185,10 +185,11 @@ Workflow:
 1. Wait for preflight to exit on build failing (the default --exit-on condition).
 2. Inspect the failed build's jobs logs and test failures and start fixing the issue immediately.
 3. Keep the build number or preflight UUID from the run output.
-4. Use `bk build view` to check the same build again while it continues running:
+4. Check the build state without downloading jobs, artifacts, annotations, or expanded pipeline details. Query failed jobs separately through the REST List Jobs endpoint:
 
 ```bash
-bk build view <build-number> -p my-org/my-pipeline --text
+bk build view 429 -p my-org/my-pipeline --summary --text
+bk job list --pipeline my-org/my-pipeline --build 429 --state failed --no-limit --text
 ```
 
 5. After the build reaches a terminal state and you no longer need the remote preflight branch, clean it up explicitly:

--- a/steering/api.md
+++ b/steering/api.md
@@ -10,7 +10,7 @@ description: This skill should be used when the user asks to "call the Buildkite
 
 Buildkite exposes a REST API and a GraphQL API for programmatic automation, plus webhooks for event-driven integrations. Use the REST API for straightforward CRUD operations on builds, pipelines, and organizations. Use the GraphQL API for mutations (queue creation, template management, cluster operations) and when fetching nested or specific fields. Use webhooks to react to build and agent events in real time.
 
-> To execute API calls interactively from the terminal, see the **buildkite-cli** skill for `bk api` commands. To use the Buildkite MCP server for direct agent access to builds, logs, and pipelines, the MCP server exposes its own tool schemas — no API construction needed.
+> To execute API calls interactively from the terminal, see the **buildkite-cli** skill for `bk api` commands. With the Buildkite MCP server, use `list_builds` and `get_build` for build metadata without jobs or expanded pipeline information; use `list_jobs` and `get_job` only when job details are needed.
 
 ## Quick Start
 
@@ -18,7 +18,8 @@ List builds for a pipeline using the REST API:
 
 ```bash
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?per_page=5" | jq '.[].state'
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?exclude_jobs=true&exclude_pipeline=true&per_page=5" \
+  | jq '.[].state'
 ```
 
 Query the same data via GraphQL:
@@ -86,6 +87,8 @@ Base URL: `https://api.buildkite.com/v2`
 
 All responses return JSON. Use `Content-Type: application/json` for request bodies.
 
+Default build list and get requests to `exclude_jobs=true`. Also set `exclude_pipeline=true` unless expanded pipeline information is required. Retrieve jobs from the Jobs API rather than expanding every job into a build response.
+
 ### Endpoint Reference
 
 All endpoints are under `/organizations/{org.slug}`. Abbreviated as `/{org}` below.
@@ -99,7 +102,7 @@ All endpoints are under `/organizations/{org.slug}`. Abbreviated as `/{org}` bel
 | Builds (org) | `/{org}/builds` | GET | `read_builds` |
 | Builds (pipeline) | `/{org}/pipelines/{slug}/builds` | GET, POST | `read_builds`, `write_builds` |
 | Build | `/{org}/pipelines/{slug}/builds/{num}` | GET | `read_builds` |
-| Jobs | `/{org}/pipelines/{slug}/builds/{num}/jobs` | GET | `read_builds` |
+| Jobs (build) | `/{org}/pipelines/{slug}/builds/{num}/jobs` | GET | `read_builds` |
 | Job log | `/{org}/pipelines/{slug}/builds/{num}/jobs/{id}/log` | GET, DELETE | `read_build_logs` |
 | Job env | `/{org}/pipelines/{slug}/builds/{num}/jobs/{id}/env` | GET | `read_job_env` |
 | Artifacts (build) | `/{org}/pipelines/{slug}/builds/{num}/artifacts` | GET | `read_artifacts` |
@@ -116,11 +119,11 @@ All endpoints are under `/organizations/{org.slug}`. Abbreviated as `/{org}` bel
 
 ### Pagination
 
-REST responses are paginated using HTTP `Link` headers:
+Most REST list responses are paginated using HTTP `Link` headers. The List Jobs endpoint instead returns cursor links in the response body, as described below.
 
 ```
-Link: <https://api.buildkite.com/v2/organizations/my-org/builds?page=2&per_page=30>; rel="next",
-      <https://api.buildkite.com/v2/organizations/my-org/builds?page=5&per_page=30>; rel="last"
+Link: <https://api.buildkite.com/v2/organizations/my-org/builds?exclude_jobs=true&exclude_pipeline=true&page=2&per_page=30>; rel="next",
+      <https://api.buildkite.com/v2/organizations/my-org/builds?exclude_jobs=true&exclude_pipeline=true&page=5&per_page=30>; rel="last"
 ```
 
 | Parameter | Default | Max | Description |
@@ -135,7 +138,7 @@ Parse the `Link` header to follow `rel="next"` until no next link exists.
 ```bash
 # Filter by state and branch
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?state=failed&branch=main"
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?exclude_jobs=true&exclude_pipeline=true&state=failed&branch=main"
 ```
 
 Build list query parameters:
@@ -148,8 +151,33 @@ Build list query parameters:
 | `commit` | Commit SHA | `commit=abc123` |
 | `created_from` | Builds after (ISO 8601) | `created_from=2024-01-01T00:00:00Z` |
 | `created_to` | Builds before (ISO 8601) | `created_to=2024-12-31T23:59:59Z` |
+| `exclude_jobs` | Exclude embedded jobs; use for state polling and metadata | `exclude_jobs=true` |
+| `exclude_pipeline` | Exclude expanded pipeline information | `exclude_pipeline=true` |
 | `include_retried_jobs` | Include retried executions | `include_retried_jobs=true` |
 | `meta_data` | Filter by metadata | `meta_data[deploy]=true` |
+
+### Get a Build
+
+Use a build number, not a build UUID. Keep metadata and status checks lightweight:
+
+```bash
+curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42?exclude_jobs=true&exclude_pipeline=true"
+```
+
+Omit an exclusion only when the response must include that expansion.
+
+### List Jobs
+
+Query jobs directly once the build number is known. Do not fetch the build again with embedded jobs. The endpoint supports server-side state filtering, including `failed` jobs in large or still-running builds.
+
+```bash
+curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?state[]=failed&include_retried_jobs=false&per_page=100" \
+  | jq '.items[] | {id, name, state, exit_status, web_url}'
+```
+
+This endpoint uses cursor pagination: read jobs from `.items` and follow `.links.next` until it is `null`. `include_retried_jobs` defaults to `true`; set it to `false` when only the latest attempt for each step is needed.
 
 ### Create a Build
 
@@ -243,7 +271,9 @@ Endpoint: `https://graphql.buildkite.com/v1`. The GraphQL API supports queries a
 | Scenario | Use | Why |
 |----------|-----|-----|
 | Trigger a build | Either | Both support it; REST is simpler |
+| Poll build state or read metadata | REST | Set `exclude_jobs=true&exclude_pipeline=true` to avoid unused expansions |
 | List builds with filtering | REST | Better query parameter support |
+| List jobs for one build | REST Jobs API | Server-side job filtering without expanding the build response |
 | Fetch build + jobs + artifacts in one call | GraphQL | Single request, no N+1 |
 | Simple CRUD on pipelines, clusters, queues | REST | Simpler request/response |
 | Audit events | GraphQL | `auditEvent` query available |
@@ -261,6 +291,7 @@ Most commonly used events: `build.finished` (react to build completion), `job.fi
 
 | Mistake | What happens | Fix |
 |---------|-------------|-----|
+| Polling build list/get endpoints with embedded jobs | Repeatedly transfers every job and expanded pipeline data | Add `exclude_jobs=true&exclude_pipeline=true`; query the Jobs API only when job details are needed |
 | Using pipeline slug as GraphQL `pipelineID` | Mutation fails with "not found" error | Query the pipeline first to get its `id` (base64-encoded GraphQL node ID), then use that in mutations |
 | Missing `Content-Type: application/json` on POST requests | 422 error or empty response body | Always include `-H "Content-Type: application/json"` for POST/PUT/PATCH requests |
 | Not following `Link` header pagination | Only get first 30 results, missing data | Parse the `Link` header for `rel="next"` and loop until no next link exists |

--- a/steering/cli.md
+++ b/steering/cli.md
@@ -158,9 +158,9 @@ bk build view --mine --summary      # latest build by the current user
 ### List builds
 
 ```bash
-bk build list --summary                              # 50 compact build summaries
+bk build list --summary                              # 50 most recent build summaries
 bk build list --summary --state failed --branch main # filter by state and branch
-bk build list --summary --since 24h                  # recent build states
+bk build list --summary --since 24h --duration ">20m" # slow builds from the last 24 hours
 bk build list --summary --meta-data env=production -o json
 ```
 

--- a/steering/cli.md
+++ b/steering/cli.md
@@ -14,6 +14,8 @@ The Buildkite CLI (`bk`) provides terminal access to builds, jobs, pipelines, se
 
 ## Quick Start
 
+`bk job list --build` requires Buildkite CLI v3.53.0 or later. Run `bk update` if the flag is unavailable.
+
 ```bash
 # Install
 brew install buildkite/buildkite/bk
@@ -27,8 +29,9 @@ bk build create
 # Watch the most recent build run
 bk build watch
 
-# Inspect a build and read a failed job's log
-bk build view
+# Inspect build state, find failed jobs, and read a failed job's log
+bk build view 429 --summary
+bk job list --pipeline my-app --build 429 --state failed
 bk job log <job-uuid>
 ```
 
@@ -143,24 +146,25 @@ bk build create -w
 
 `bk build view` (and most build commands) default to the most recent build on the current branch.
 
+Use `--summary` for status checks, polling, scripts, and agent workflows. It excludes jobs and expanded pipeline information, and skips artifact and annotation requests.
+
 ```bash
-bk build view                  # most recent build on the current branch
-bk build view 429              # a specific build number
-bk build view -s failed,broken # only show failed/broken jobs
-bk build view --mine           # most recent build by the current user
-bk build view 429 -o json      # structured output
+bk build view --summary             # latest build metadata and state
+bk build view 429 --summary         # a specific build number
+bk build view 429 --summary -o json # compact structured output
+bk build view --mine --summary      # latest build by the current user
 ```
 
 ### List builds
 
 ```bash
-bk build list                                   # 50 most recent
-bk build list --state failed --branch main      # filter by state and branch
-bk build list --since 24h --duration ">20m"     # recent slow builds
-bk build list --meta-data env=production -o json
+bk build list --summary                              # 50 compact build summaries
+bk build list --summary --state failed --branch main # filter by state and branch
+bk build list --summary --since 24h                  # recent build states
+bk build list --summary --meta-data env=production -o json
 ```
 
-Server-side filters (fast): `--pipeline`, `--since`, `--until`, `--state`, `--branch`, `--creator`, `--commit`, `--meta-data`. Client-side filters: `--duration`, `--message`. Valid states: `running`, `scheduled`, `passed`, `failed`, `blocked`, `canceled`, `canceling`, `skipped`, `not_run`. Pass `--state` and `--branch` as comma-separated lists. Use `--limit N` (default 50) or `--no-limit` to control paging. See `cli/references/command-reference.md` for the full filter table.
+Use `--summary` for metadata-only output; the API requests exclude jobs and expanded pipeline information. Server-side filters (fast): `--pipeline`, `--since`, `--until`, `--state`, `--branch`, `--creator`, `--commit`, `--meta-data`. Client-side filters: `--duration`, `--message`. Valid states: `running`, `scheduled`, `passed`, `failed`, `blocked`, `canceled`, `canceling`, `skipped`, `not_run`. Pass `--state` and `--branch` as comma-separated lists. Use `--limit N` (default 50) or `--no-limit` to control paging. See `cli/references/command-reference.md` for the full filter table.
 
 ### Watch a build
 
@@ -207,12 +211,21 @@ bk job log <job-uuid> --no-timestamps   # strip timestamp prefixes
 
 ### List jobs
 
-`bk job list` extracts jobs across recent builds, with server-side (`--pipeline`, `--since`, `--until`) and client-side (`--queue`, `--state`, `--duration`) filters.
+When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state` is applied server-side; `--queue` and `--duration` remain client-side.
+
+```bash
+bk job list --pipeline my-app --build 429 --state failed
+bk job list --build 429 --state running # pipeline auto-detected
+```
+
+Without `--build`, the command searches across recent builds and extracts their embedded jobs:
 
 ```bash
 bk job list --queue test-queue --state running
 bk job list --duration ">10m" --order-by duration --no-limit
 ```
+
+`--limit` caps the total jobs emitted, not the API page size. Use `--no-limit` to follow every cursor page. `--since` and `--until` cannot be combined with `--build`.
 
 ### Retry, cancel, unblock, reprioritize
 
@@ -227,9 +240,9 @@ bk job reprioritize <job-uuid> 10 # raise scheduling priority
 ### Debugging workflow
 
 ```bash
-bk build list --state failed -p my-app   # find failed builds
-bk build view 429 -p my-app -s failed    # identify the failed jobs
-bk job log <job-uuid>                     # read the failing log
+bk build list --summary --state failed -p my-app
+bk job list --pipeline my-app --build 429 --state failed
+bk job log <job-uuid>
 ```
 
 ## Pipelines
@@ -372,9 +385,9 @@ bk skill add buildkite-api   # install a Buildkite skill into the current agent
 Make direct REST or GraphQL calls with `bk api`:
 
 ```bash
-bk api /pipelines/my-app/builds/429                    # REST GET (org inferred)
+bk api '/pipelines/my-app/builds/429?exclude_jobs=true&exclude_pipeline=true'
 bk api -X POST /pipelines --data '{"name":"New","repository":"git@..."}'
-bk api --file query.graphql                                      # GraphQL (file with a named operation)
+bk api --file query.graphql # GraphQL file with a named operation
 ```
 
 > For comprehensive REST and GraphQL documentation (endpoints, mutations, pagination, webhooks), see the **buildkite-api** skill.
@@ -386,7 +399,9 @@ When the Buildkite MCP server is available, prefer MCP tools for read operations
 | CLI Command | MCP Tool | Notes |
 |-------------|----------|-------|
 | `bk build create` | `create_build` | MCP handles auth automatically |
-| `bk build view` / `list` | `get_build` / `list_builds` | Same filters; structured output |
+| `bk build view --summary` / `list --summary` | `get_build` / `list_builds` | Metadata only; jobs and expanded pipeline information are excluded |
+| `bk job list --build` | `list_jobs` | List jobs without expanding the build response |
+| — | `get_job` | MCP-only single-job metadata lookup |
 | `bk job log` | `read_logs`, `tail_logs` | MCP supports streaming |
 | `bk pipeline list` / `view` / `create` | `list_pipelines`, `get_pipeline`, `create_pipeline` | |
 | `bk artifacts list` / `download` | `list_artifacts_for_build`, `get_artifact` | |
@@ -401,13 +416,15 @@ When the Buildkite MCP server is available, prefer MCP tools for read operations
 
 | Mistake | What happens | Fix |
 |---------|-------------|-----|
+| Using full build responses for status polling | Downloads jobs, pipeline details, artifacts, and annotations repeatedly | Use `bk build view --summary` or `bk build list --summary` |
+| Omitting `--build` when the build number is known | Scans recent build responses and extracts their embedded jobs | Use `bk job list --pipeline my-app --build 429`, or MCP `list_jobs` |
 | Running `bk` commands before authenticating | Commands fail with authentication errors | Run `bk auth login` (or `bk configure` with a token) first |
 | Running `bk auth login` in Docker/CI expecting a browser | Hangs — no browser or keychain available | Use `bk auth login --org my-org --token "$TOKEN"`, or `--device` for headless |
 | Passing `-p`/`-b` to `bk job log` | Flags are deprecated and ignored — job UUIDs are self-contained | Pass only the job UUID |
 | Retrying a job UUID that was already retried | API returns 422 — each UUID retries once | Use the new job UUID returned by the first retry |
 | Creating secrets with keys starting with `buildkite`/`bk` | Creation fails — reserved prefix | Choose another name (exception: `BUILDKITE_API_TOKEN`) |
 | Passing secret values literally in `--value` | Values persist in shell history and process list | Use env var references (`--value "$TOKEN"`) or the masked prompt |
-| Running `bk build cancel` on a finished build | API errors — only scheduled/running/failing builds cancel | Check state with `bk build view` first |
+| Running `bk build cancel` on a finished build | API errors — only scheduled/running/failing builds cancel | Check state with `bk build view --summary` first |
 | Assuming `bk artifacts upload` exists | No such command | Upload from a job with `buildkite-agent artifact upload` |
 | Confusing `bk` with `buildkite-agent` | `bk` runs locally against the API; `buildkite-agent` runs inside job steps | Use `bk` from a terminal, `buildkite-agent` inside pipeline commands |
 

--- a/steering/preflight.md
+++ b/steering/preflight.md
@@ -175,7 +175,7 @@ Check the exit code to determine the build result:
 
 ## Optional Workflow: Act On A Failure And Check Back Later
 
-Begin fixing the first failure as soon as preflight exits with an incomplete build result because the build is failing, and then check back on the same build with `bk build view` for subsequent failures. This allows you to quickly iterate on the first failure, and gather further failures in parallel. Use the `bk preflight --no-cleanup` option to ensure that build is not cancled on fast failure.
+Begin fixing the first failure as soon as preflight exits with an incomplete build result because the build is failing. Check the same build's summary while it continues, then query failed jobs directly for subsequent failures. This allows you to quickly iterate on the first failure, and gather further failures in parallel. Use the `bk preflight --no-cleanup` option to ensure that build is not canceled on fast failure.
 
 ```bash
 bk preflight --pipeline my-org/my-pipeline --watch --no-cleanup --text
@@ -188,10 +188,11 @@ Workflow:
 1. Wait for preflight to exit on build failing (the default --exit-on condition).
 2. Inspect the failed build's jobs logs and test failures and start fixing the issue immediately.
 3. Keep the build number or preflight UUID from the run output.
-4. Use `bk build view` to check the same build again while it continues running:
+4. Check the build state without downloading jobs, artifacts, annotations, or expanded pipeline details. Query failed jobs separately through the REST List Jobs endpoint:
 
 ```bash
-bk build view <build-number> -p my-org/my-pipeline --text
+bk build view 429 -p my-org/my-pipeline --summary --text
+bk job list --pipeline my-org/my-pipeline --build 429 --state failed --no-limit --text
 ```
 
 5. After the build reaches a terminal state and you no longer need the remote preflight branch, clean it up explicitly:


### PR DESCRIPTION
## Description

Build list and get endpoints embed every job unless callers explicitly exclude them. Status checks usually need only build metadata, so these skill updates teach coding agents and LLMs to:

- request `exclude_jobs=true&exclude_pipeline=true` for REST build metadata
- use `bk build view --summary` and `bk build list --summary` for CLI status checks
- retrieve jobs for a known build with `bk job list --build`
- use the cursor-paginated List Jobs endpoint for direct REST requests
- use `list_builds` and `get_build` for MCP build metadata, then `list_jobs` and `get_job` for job details
- fetch preflight build state and failed jobs separately

Fetching jobs separately reduces API response size and avoids repeatedly transferring unused job and pipeline data.

## Compatibility

`bk job list --build` requires Buildkite CLI v3.53.0 or later. Users on older versions should run `bk update`.

Existing REST consumers can continue requesting embedded jobs by omitting `exclude_jobs=true`.

## Deployment

Documentation and generated steering guidance only. This does not change runtime behavior.

## Rollback

Revert the commit if the guidance causes compatibility or workflow problems.

## Related

- [buildkite/cli#911](https://github.com/buildkite/cli/pull/911)
- [buildkite/cli#913](https://github.com/buildkite/cli/pull/913)