### PR TITLE
Document job step and group filters

### DIFF
--- a/skills/buildkite-api/SKILL.md
+++ b/skills/buildkite-api/SKILL.md
@@ -174,15 +174,15 @@ Omit an exclusion only when the response must include that expansion.
 
 ### List Jobs
 
-Query jobs directly once the build number is known. Do not fetch the build again with embedded jobs. The endpoint supports server-side state filtering, including `failed` jobs in large or still-running builds.
+Query jobs directly once the build number is known. Do not fetch the build again with embedded jobs. Prefer server-side `state`, `step_key`, and `group_key` filters to fetching every job and filtering locally. A step key matches every job for that step, including parallel jobs; a group key matches every job in that group.
 
 ```bash
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?state[]=failed&include_retried_jobs=false&per_page=100" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?state[]=failed&group_key=verification&include_retried_jobs=false&per_page=100" \
   | jq '.items[] | {id, name, state, exit_status, web_url}'
 ```
 
-This endpoint uses cursor pagination: read jobs from `.items` and follow `.links.next` until it is `null`. `include_retried_jobs` defaults to `true`; set it to `false` when only the latest attempt for each step is needed.
+This endpoint uses cursor pagination: read jobs from `.items` and follow `.links.next` until it is `null`. Follow the returned next URL as-is so `state[]`, `step_key`, `group_key`, and `include_retried_jobs` remain applied on every page. `include_retried_jobs` defaults to `true`; set it to `false` when only the latest attempt for each step is needed.
 
 ### Create a Build
 

--- a/skills/buildkite-api/references/patterns.md
+++ b/skills/buildkite-api/references/patterns.md
@@ -40,6 +40,18 @@ curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
 
 Follow `.links.next` when it is not `null`.
 
+## Fetch Jobs for a Step or Group
+
+Filter on the server when only one step or group is relevant. `step_key` returns all jobs for the step, including parallel jobs. `group_key` returns all jobs in the group.
+
+```bash
+curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?step_key=test&group_key=verification&per_page=100" \
+  | jq '.items[] | {id, name, state, web_url}'
+```
+
+Follow each `.links.next` URL as returned; rebuilding the URL can drop filters between cursor pages.
+
 ## Trigger Downstream Pipeline
 
 ```python

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -219,11 +219,13 @@ bk job log <job-uuid> --no-timestamps   # strip timestamp prefixes
 
 ### List jobs
 
-When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state` is applied server-side; `--queue` and `--duration` remain client-side.
+When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state`, `--step-key`, and `--group-key` are applied server-side; `--queue` and `--duration` remain client-side. Use `--step-key` for every job in a step, including parallel jobs, and `--group-key` for every job in a group.
 
 ```bash
 bk job list --pipeline my-app --build 429 --state failed
 bk job list --build 429 --state running # pipeline auto-detected
+bk job list --build 429 --step-key test
+bk job list --build 429 --group-key verification
 ```
 
 Without `--build`, the command searches across recent builds and extracts their embedded jobs:
@@ -233,7 +235,7 @@ bk job list --queue test-queue --state running
 bk job list --duration ">10m" --order-by duration --no-limit
 ```
 
-`--limit` caps the total jobs emitted, not the API page size. Use `--no-limit` to follow every cursor page. `--since` and `--until` cannot be combined with `--build`.
+`--step-key` and `--group-key` require `--build` and can be combined. `--limit` caps the total jobs emitted, not the API page size. Use `--no-limit` to follow every cursor page; the CLI preserves all server-side filters across cursor pages. `--since` and `--until` cannot be combined with `--build`.
 
 ### Retry, cancel, unblock, reprioritize
 

--- a/skills/buildkite-cli/SKILL.md
+++ b/skills/buildkite-cli/SKILL.md
@@ -219,6 +219,8 @@ bk job log <job-uuid> --no-timestamps   # strip timestamp prefixes
 
 ### List jobs
 
+`--step-key` and `--group-key` require Buildkite CLI v3.54.0 or later. Run `bk update` if either flag is unavailable.
+
 When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state`, `--step-key`, and `--group-key` are applied server-side; `--queue` and `--duration` remain client-side. Use `--step-key` for every job in a step, including parallel jobs, and `--group-key` for every job in a group.
 
 ```bash

--- a/skills/buildkite-cli/references/command-reference.md
+++ b/skills/buildkite-cli/references/command-reference.md
@@ -113,12 +113,14 @@ These default to the most recent build on the current branch. Shared flags: `-p/
 
 ### `bk job list`
 
-Pass `--build` when the build number is known. This uses the dedicated cursor-paginated List Jobs endpoint instead of searching build responses. The pipeline can be passed with `--pipeline` or resolved from the current repository or configuration. `--limit` remains the total output cap; `--no-limit` follows every cursor page. `--since` and `--until` cannot be combined with `--build`.
+Pass `--build` when the build number is known. This uses the dedicated cursor-paginated List Jobs endpoint instead of searching build responses. The pipeline can be passed with `--pipeline` or resolved from the current repository or configuration. `--step-key` and `--group-key` require `--build`, can be combined, and remain applied across cursor pages. A step key includes parallel jobs for that step; a group key includes every job in that group. `--limit` remains the total output cap; `--no-limit` follows every cursor page. `--since` and `--until` cannot be combined with `--build`.
 
 | Flag | Default | Description | Side |
 |------|---------|-------------|------|
 | `--pipeline` (`-p`) | — | Filter by pipeline slug | server |
 | `--build` | — | Filter by build number; requires a resolvable pipeline | server |
+| `--step-key` | — | Filter by step key; requires `--build` | server with `--build` |
+| `--group-key` | — | Filter by group key; requires `--build` | server with `--build` |
 | `--since` | — | Builds created since (e.g. `1h`) | server |
 | `--until` | — | Builds created before (e.g. `1h`) | server |
 | `--queue` | — | Filter by queue name | client |

--- a/steering/api.md
+++ b/steering/api.md
@@ -169,15 +169,15 @@ Omit an exclusion only when the response must include that expansion.
 
 ### List Jobs
 
-Query jobs directly once the build number is known. Do not fetch the build again with embedded jobs. The endpoint supports server-side state filtering, including `failed` jobs in large or still-running builds.
+Query jobs directly once the build number is known. Do not fetch the build again with embedded jobs. Prefer server-side `state`, `step_key`, and `group_key` filters to fetching every job and filtering locally. A step key matches every job for that step, including parallel jobs; a group key matches every job in that group.
 
 ```bash
 curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?state[]=failed&include_retried_jobs=false&per_page=100" \
+  "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds/42/jobs?state[]=failed&group_key=verification&include_retried_jobs=false&per_page=100" \
   | jq '.items[] | {id, name, state, exit_status, web_url}'
 ```
 
-This endpoint uses cursor pagination: read jobs from `.items` and follow `.links.next` until it is `null`. `include_retried_jobs` defaults to `true`; set it to `false` when only the latest attempt for each step is needed.
+This endpoint uses cursor pagination: read jobs from `.items` and follow `.links.next` until it is `null`. Follow the returned next URL as-is so `state[]`, `step_key`, `group_key`, and `include_retried_jobs` remain applied on every page. `include_retried_jobs` defaults to `true`; set it to `false` when only the latest attempt for each step is needed.
 
 ### Create a Build
 

--- a/steering/cli.md
+++ b/steering/cli.md
@@ -211,6 +211,8 @@ bk job log <job-uuid> --no-timestamps   # strip timestamp prefixes
 
 ### List jobs
 
+`--step-key` and `--group-key` require Buildkite CLI v3.54.0 or later. Run `bk update` if either flag is unavailable.
+
 When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state`, `--step-key`, and `--group-key` are applied server-side; `--queue` and `--duration` remain client-side. Use `--step-key` for every job in a step, including parallel jobs, and `--group-key` for every job in a group.
 
 ```bash

--- a/steering/cli.md
+++ b/steering/cli.md
@@ -211,11 +211,13 @@ bk job log <job-uuid> --no-timestamps   # strip timestamp prefixes
 
 ### List jobs
 
-When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state` is applied server-side; `--queue` and `--duration` remain client-side.
+When the build number is known, pass `--build` so `bk job list` uses the dedicated cursor-paginated List Jobs endpoint. The pipeline can be explicit or resolved from the current repository or configuration. `--state`, `--step-key`, and `--group-key` are applied server-side; `--queue` and `--duration` remain client-side. Use `--step-key` for every job in a step, including parallel jobs, and `--group-key` for every job in a group.
 
 ```bash
 bk job list --pipeline my-app --build 429 --state failed
 bk job list --build 429 --state running # pipeline auto-detected
+bk job list --build 429 --step-key test
+bk job list --build 429 --group-key verification
 ```
 
 Without `--build`, the command searches across recent builds and extracts their embedded jobs:
@@ -225,7 +227,7 @@ bk job list --queue test-queue --state running
 bk job list --duration ">10m" --order-by duration --no-limit
 ```
 
-`--limit` caps the total jobs emitted, not the API page size. Use `--no-limit` to follow every cursor page. `--since` and `--until` cannot be combined with `--build`.
+`--step-key` and `--group-key` require `--build` and can be combined. `--limit` caps the total jobs emitted, not the API page size. Use `--no-limit` to follow every cursor page; the CLI preserves all server-side filters across cursor pages. `--since` and `--until` cannot be combined with `--build`.
 
 ### Retry, cancel, unblock, reprioritize
 


### PR DESCRIPTION
## Description

Document the List Jobs `step_key` and `group_key` server-side filters and the matching `bk job list --build` flags. The guidance explains step, group, and cursor-pagination behavior so agents can filter large builds without fetching every job.

Related client changes:
- [go-buildkite #347](https://github.com/buildkite/go-buildkite/pull/347), released in [v5.7.0](https://github.com/buildkite/go-buildkite/releases/tag/v5.7.0)
- [CLI #915](https://github.com/buildkite/cli/pull/915)

## Deployment

Merge only after:

1. Server-side API support is deployed.
2. The [public API docs](https://buildkite.com/docs/apis/rest-api/jobs#list-jobs) are live.
3. CLI #915 ships.

## Rollback

Revert this PR if the documented filters or flags change before release. The change affects guidance and generated steering content only.
